### PR TITLE
Add support for title page title decoration

### DIFF
--- a/assets/styles/components/pages/_titles.scss
+++ b/assets/styles/components/pages/_titles.scss
@@ -36,6 +36,17 @@ h1.title {
   word-spacing: $title-title-word-spacing;
   text-align: $title-title-align;
   text-transform: $title-title-text-transform;
+
+  &::after {
+    font-family: $title-title-decoration-font-family;
+    content: $title-title-decoration-content;
+    display: $title-title-decoration-display;
+    white-space: pre;
+    font-size: if-map-get($title-title-decoration-font-size, $type);
+    font-weight: $title-title-decoration-font-weight;
+    margin-bottom: if-map-get($title-title-decoration-margin-bottom, $type);
+    margin-top: if-map-get($title-title-decoration-margin-top, $type);
+  }
 }
 
 h2.subtitle {

--- a/assets/styles/variables/_pages.scss
+++ b/assets/styles/variables/_pages.scss
@@ -116,6 +116,41 @@ $title-title-align: center !default;
 /// @type String
 $title-title-text-transform: none !default;
 
+/// Defines the title page title decoration font family.
+/// @type String
+/// @since 1.0.0
+$title-title-decoration-font-family: $font-3 !default;
+
+/// Defines the title page title decoration content.
+/// @type String 
+/// @since 1.0.0
+$title-title-decoration-content: "" !default;
+
+/// Defines the title page title decoration display.
+/// @type String
+/// @since 1.0.0
+$title-title-decoration-display: none !default;
+
+/// Defines the title page title decoration font size.
+/// @type String | Map
+/// @since 1.0.0
+$title-title-decoration-font-size: (epub:  0em, prince: 0em, web: 0em) !default;
+
+/// Defines the title page title decoration font weight.
+/// @type String 
+/// @since 1.0.0
+$title-title-decoration-font-weight: normal !default;
+
+/// Defines the title page title decoration margin bottom.
+/// @type String | Map
+/// @since 1.0.0
+$title-title-decoration-margin-bottom: (epub:  0em, prince: 0em, web: 0em) !default;
+
+/// Defines the title page title decoration margin top.
+/// @type String | Map
+/// @since 1.0.0
+$title-title-decoration-margin-top:  (epub:  0em, prince: 0em, web: 0em) !default;
+
 // Subtitle
 
 /// Top margin for title page subtitle on elements `<h2>` with a class of `subtitle`.


### PR DESCRIPTION
Since the title page title variables are in pages, the title page title decoration does not point to the $section-title-decoration variables for default values. Is this alright?