### PR TITLE
Add border bottom to part title

### DIFF
--- a/assets/styles/components/section-titles/_parts.scss
+++ b/assets/styles/components/section-titles/_parts.scss
@@ -50,6 +50,7 @@
       page-break-after: avoid;
       letter-spacing: if-map-get($part-title-letter-spacing, $type);
       word-spacing: if-map-get($part-title-word-spacing, $type);
+      border-bottom: if-map-get($part-title-border-bottom-width, $type) $part-title-border-bottom-style if-map-get($part-title-border-bottom-color, $type);
 
       &::after {
         font-family: $part-title-decoration-font-family;

--- a/assets/styles/variables/_section-titles.scss
+++ b/assets/styles/variables/_section-titles.scss
@@ -711,6 +711,21 @@ $part-title-decoration-margin-bottom: $section-title-decoration-margin-bottom !d
 /// @since 1.0.0
 $part-title-decoration-margin-top: $section-title-decoration-margin-top !default;
 
+/// Defines the bottom border width for the part title.
+/// @type String | Map
+/// @since 1.1.0
+$part-title-border-bottom-width: (epub: 0, prince: 0, web: 0) !default;
+
+/// Defines the bottom border style for the part title.
+/// @type String
+/// @since 1.1.0
+$part-title-border-bottom-style: $section-title-border-bottom-style !default;
+
+/// Defines the bottom border colour for the part title.
+/// @type String | Map
+/// @since 1.1.0
+$part-title-border-bottom-color: $section-title-border-bottom-color !default;
+
 /// Defines the front matter title display property.
 /// @type String
 /// @since 0.3.0


### PR DESCRIPTION
$part-title-border-bottom-width is set to 0. I am adding this feature so it does not have to be set in custom CSS, as it is automatically targeted when headers are set to have bottom borders. I have not yet encountered an instance where there is a bottom border on the part title so I did not want to set its value to $section-title-border-bottom-width and break previous changes.