### PR TITLE
Omit link colour rules for EPUB/MOBI (fix #226)

### DIFF
--- a/assets/styles/components/_colors.scss
+++ b/assets/styles/components/_colors.scss
@@ -5,12 +5,13 @@
 @import 'utilities';
 
 // STANDARD TEXT COLORS
-
-@if $type != 'web' {
+@if $type == 'prince' {
   a {
     color: if-map-get($link-color, $type);
   }
+}
 
+@if $type != 'web' {
   body,
   .entry-content {
     color: if-map-get($body-color, $type);

--- a/assets/styles/components/toc/_generic.scss
+++ b/assets/styles/components/toc/_generic.scss
@@ -24,7 +24,6 @@
     }
 
     a {
-      color: inherit;
       border: 0;
     }
 

--- a/assets/styles/variables/_colors.scss
+++ b/assets/styles/variables/_colors.scss
@@ -21,7 +21,6 @@ $color-6: $color-1 !default;
 /// Color for `<a>` elements.
 /// @type String | Map
 $link-color: (
-  epub: initial,
   prince: initial,
   web: var(--primary, #b01109)
 ) !default;


### PR DESCRIPTION
Right now links in EPUB/MOBI are the same colour as body text. This is Not Good™. This PR removes link colour styles for EPUB/MOBI.