### PR TITLE
Centre videos embedded from the media library

### DIFF
--- a/assets/styles/components/media/_video.scss
+++ b/assets/styles/components/media/_video.scss
@@ -9,3 +9,10 @@
     background-image: url(if-map-get($video-icon-url, $type));
   }
 }
+
+@if $type == 'web' {
+  .wp-video {
+    display: block;
+    margin: 0 auto if-map-get($interactive-content-margin-bottom, $type);
+  }
+}


### PR DESCRIPTION
This PR adds left and right auto margins to centre
video embedded from the media library for consistency
with #158 (which addressed embeds in iframes).