### PR TITLE
fix: resolve issues with extending compound selectors

### DIFF
--- a/assets/styles/components/specials/_textboxes.scss
+++ b/assets/styles/components/specials/_textboxes.scss
@@ -180,20 +180,32 @@
   }
 }
 
+%learning-objectives {
+  @include educational-textbox($learning-objectives-header-color, $learning-objectives-header-background, $learning-objectives-color, $learning-objectives-background);
+}
+
+%key-takeaways {
+  @include educational-textbox($key-takeaways-header-color, $key-takeaways-header-background, $key-takeaways-color, $key-takeaways-background);
+}
+
+%exercises {
+  @include educational-textbox($exercises-header-color, $exercises-header-background, $exercises-color, $exercises-background);
+}
+
 .bcc-box {
   @extend .textbox;
 }
 
 .bcc-highlight {
-  @extend .textbox.learning-objectives;
+  @extend %learning-objectives;
 }
 
 .bcc-success {
-  @extend .textbox.key-takeaways;
+  @extend %key-takeaways;
 }
 
 .bcc-info {
-  @extend .textbox.exercises;
+  @extend %exercises;
 }
 
 .textbox--sidebar {

--- a/composer.json
+++ b/composer.json
@@ -2,8 +2,6 @@
 	"name": "pressbooks/buckram",
 	"description": "Opinionated SCSS components for books (web, EPUB and PDF).",
 	"license": "GPL-3.0-or-later",
-	"require-dev": {
-	},
 	"scripts": {
 		"test": [
 			"vendor/bin/pscss tests/source/styles/epub-toc-left.scss > tests/output/css/epub-toc-left.css",
@@ -13,7 +11,7 @@
 			"vendor/bin/pscss tests/source/styles/web.scss > tests/output/css/web.css"
 		]
 	},
-	"require": {
-		"scssphp/scssphp": "^1.0"
+	"require-dev": {
+		"scssphp/scssphp": "1.2"
 	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c78da389695d65025b27ba3f1d1e673a",
-    "packages": [
+    "content-hash": "a3befa46e77fe739dad90e1b40754adf",
+    "packages": [],
+    "packages-dev": [
         {
             "name": "scssphp/scssphp",
-            "version": "1.0.5",
+            "version": "1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/scssphp/scssphp.git",
-                "reference": "98e10149058102817b493c5a147fa582cb62d46e"
+                "reference": "ce970268a912dabbfaa0eff65dbc5e4a2a6cb757"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/scssphp/scssphp/zipball/98e10149058102817b493c5a147fa582cb62d46e",
-                "reference": "98e10149058102817b493c5a147fa582cb62d46e",
+                "url": "https://api.github.com/repos/scssphp/scssphp/zipball/ce970268a912dabbfaa0eff65dbc5e4a2a6cb757",
+                "reference": "ce970268a912dabbfaa0eff65dbc5e4a2a6cb757",
                 "shasum": ""
             },
             "require": {
@@ -27,7 +28,8 @@
             },
             "require-dev": {
                 "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.3",
-                "squizlabs/php_codesniffer": "~2.5",
+                "sass/sass-spec": "2020.08.10",
+                "squizlabs/php_codesniffer": "~3.5",
                 "twbs/bootstrap": "~4.3",
                 "zurb/foundation": "~6.5"
             },
@@ -65,15 +67,19 @@
                 "scss",
                 "stylesheet"
             ],
-            "time": "2019-10-03T17:09:15+00:00"
+            "support": {
+                "issues": "https://github.com/scssphp/scssphp/issues",
+                "source": "https://github.com/scssphp/scssphp/tree/master"
+            },
+            "time": "2020-08-26T20:47:29+00:00"
         }
     ],
-    "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
Resolves a Sass deprecation related to the extension of compound selectors (see https://sass-lang.com/documentation/breaking-changes/extend-compound)

Also: bumps scssphp/scssphp to 1.2