### PR TITLE
feat: make Buckram compatible with latest SCSSPHP

### DIFF
--- a/assets/styles/components/_utilities.scss
+++ b/assets/styles/components/_utilities.scss
@@ -13,22 +13,6 @@
   }
 }
 
-/// Replace `$search` with `$replace` in `$string`
-/// @author Kitty Giraudel
-/// @param {String} $string - Initial string
-/// @param {String} $search - Substring to replace
-/// @param {String} $replace ('') - New value
-/// @return {String} - Updated string
-@function str-replace($string, $search, $replace: '') {
-  $index: str-index($string, $search);
-
-  @if $index {
-    @return str-slice($string, 1, $index - 1) + $replace + str-replace(str-slice($string, $index + str-length($search)), $search, $replace);
-  }
-
-  @return $string;
-}
-
 /// This function converts a running content or page number position to the CSS3 paged media box margin declaration for the relevant page position.
 /// @param {string} $page-position - The page position: `first`, `left` or `right`.
 /// @param {string} $position - The running content or page number position.

--- a/assets/styles/components/_utilities.scss
+++ b/assets/styles/components/_utilities.scss
@@ -6,124 +6,92 @@
 /// @param {string | map} $var - The input variable.
 /// @param {string} $type - The output format.
 @function if-map-get($var, $type) {
-  @if type-of($var) == 'map' {
+  @if type-of($var) == "map" {
     @return map-get($var, $type);
-  } @else {
-    @return $var;
   }
+  @return $var;
 }
 
 /// This function converts a running content or page number position to the CSS3 paged media box margin declaration for the relevant page position.
 /// @param {string} $page-position - The page position: `first`, `left` or `right`.
-/// @param {string} $position - The running content or page number position.
-@function convert-position($page-position, $position) {
-  @if not $position {
-    @return false;
-  } @else if $position == 'top-outside-corner' {
-    @if $page-position != 'first' {
-      @return '@top-#{$page-position}-corner';
-    } @else {
-      @return false;
+/// @param {string} $content-position - The running content or page number position.
+@function convert-position($page-position, $content-position) {
+  @if $page-position == "first" {
+    @if $content-position == "outside-bottom" {
+      @return (left: "@left-bottom", right: "@right-bottom");
     }
-  } @else if $position == 'top-outside' {
-    @if $page-position != 'first' {
-      @return '@top-#{$page-position}';
-    } @else {
-      @return false;
+    @if $content-position == "bottom-outside-corner" {
+      @return "@bottom-#{$page-position}-corner";
     }
-  } @else if $position == 'top-center' {
-    @return '@top-center';
-  } @else if $position == 'top-inside' {
-    @if $page-position == 'left' {
-      @return '@top-right';
-    } @else if $page-position == 'right' {
-      @return '@top-left';
-    } @else {
-      @return false;
+
+    @if $content-position == "bottom-outside" {
+      @return "@bottom-#{$page-position}";
     }
-  } @else if $position == 'outside-top' {
-    @if $page-position != 'first' {
-      @return '@#{$page-position}-top';
-    } @else {
-      @return false;
+
+    @if $content-position == "bottom-inside" {
+      @return (left: "@bottom-right", right: "@bottom-left");
     }
-  } @else if $position == 'outside-middle' {
-    @if $page-position != 'first' {
-      @return '@#{$page-position}-middle';
-    } @else {
-      @return false;
+  } @else {
+    @if $content-position == "top-outside-corner" {
+      @return "@top-#{$page-position}-corner";
     }
-  } @else if $position == 'outside-bottom' {
-    @if $page-position == 'first' {
-      @return (
-        left: '@left-bottom',
-        right: '@right-bottom'
-      );
+
+    @if $content-position == "top-outside" {
+      @return "@top-#{$page-position}";
     }
-    @return '@#{$page-position}-bottom';
-  } @else if $position == 'bottom-outside-corner' {
-    @if $page-position == 'first' {
-      @return (
-        left: '@bottom-left-corner',
-        right: '@bottom-right-corner'
-      );
+
+    @if $content-position == "outside-middle" {
+      @return "@#{$page-position}-middle";
     }
-    @return '@bottom-#{$page-position}-corner';
-  } @else if $position == 'bottom-outside' {
-    @if $page-position == 'first' {
-      @return (
-        left: '@bottom-left',
-        right: '@bottom-right'
-      );
+
+    @if $content-position == "outside-top" {
+      @return "@#{$page-position}-top";
     }
-    @return '@bottom-#{$page-position}';
-  } @else if $position == 'bottom-center' {
-    @return '@bottom-center';
-  } @else if $position == 'bottom-inside' {
-    @if $page-position == 'first' {
-      @return (
-        left: '@bottom-right',
-        right: '@bottom-left'
-      );
-    } @else if $page-position == 'left' {
-      @return '@bottom-right';
-    } @else if $page-position == 'right' {
-      @return '@bottom-left';
+
+    @if $content-position == "outside-bottom" {
+      @return "@#{$page-position}-bottom";
+    }
+
+    @if $content-position == "bottom-outside"
+      or $content-position == "bottom-inside" {
+      @return "@bottom-#{$page-position}";
+    }
+
+    @if $content-position == "bottom-outside-corner" {
+      @return "@bottom-#{$page-position}-corner";
     }
   }
+
+  @if $content-position == "top-center" {
+    @return "@top-center";
+  }
+
+  @if $content-position == "bottom-center" {
+    @return "@bottom-center";
+  }
+
+  @if $content-position == "top-inside" {
+    @if $page-position == "left" {
+      @return "@top-right";
+    }
+    @if $page-position == "right" {
+      @return "@top-left";
+    }
+  }
+
+  @return false;
 }
 
 /// This function determines whether a running content or page number position indicates a header or footer.
-/// @param {string} $position - The running content or page number position.
-@function head-or-foot($position) {
-  @if $position == 'top-outside-corner'
-    or $position == '@top-left-corner'
-    or $position == '@top-right-corner'
-    or $position == 'top-outside'
-    or $position == '@top-left'
-    or $position == '@top-right'
-    or $position == 'top-center'
-    or $position == '@top-center'
-    or $position == 'top-inside'
-    or $position == 'outside-top'
-    or $position == '@left-top'
-    or $position == '@right-top'
-    or $position == 'outside-middle'
-    or $position == '@left-middle'
-    or $position == '@right-middle' {
-    @return 'head';
-  } @else if $position == 'outside-bottom'
-    or $position == 'bottom-outside-corner'
-    or $position == '@bottom-left-corner'
-    or $position == '@bottom-right-corner'
-    or $position == 'bottom-outside'
-    or $position == '@bottom-left'
-    or $position == '@bottom-right'
-    or $position == 'bottom-center'
-    or $position == '@bottom-center'
-    or $position == 'bottom-inside' {
-    @return 'foot';
-  } @else {
-    @return false;
+/// @param {string} $content-position - The running content or page number position.
+@function head-or-foot($content-position) {
+  @if str-index($content-position, "top") or
+    str-index($content-position, "middle")
+  {
+    @return "head";
+  } @else if str-index($content-position, "bottom") {
+    @return "foot";
   }
+
+  @return false;
 }

--- a/assets/styles/components/_utilities.scss
+++ b/assets/styles/components/_utilities.scss
@@ -13,6 +13,22 @@
   }
 }
 
+/// Replace `$search` with `$replace` in `$string`
+/// @author Kitty Giraudel
+/// @param {String} $string - Initial string
+/// @param {String} $search - Substring to replace
+/// @param {String} $replace ('') - New value
+/// @return {String} - Updated string
+@function str-replace($string, $search, $replace: '') {
+  $index: str-index($string, $search);
+
+  @if $index {
+    @return str-slice($string, 1, $index - 1) + $replace + str-replace(str-slice($string, $index + str-length($search)), $search, $replace);
+  }
+
+  @return $string;
+}
+
 /// This function converts a running content or page number position to the CSS3 paged media box margin declaration for the relevant page position.
 /// @param {string} $page-position - The page position: `first`, `left` or `right`.
 /// @param {string} $position - The running content or page number position.

--- a/assets/styles/components/structure/_mixins.scss
+++ b/assets/styles/components/structure/_mixins.scss
@@ -15,7 +15,7 @@
       'front-matter:#{$page-position}' {
       @page #{$page-type} {
         @if $page-position == 'first:left' {
-          @if  if-map-get($content-position, left) {
+          @if if-map-get($content-position, left) {
             @include position(if-map-get($content-position, left)) {
               @if head-or-foot($content-position) == 'head' {
                 padding-top: $runninghead-padding-top;
@@ -27,7 +27,7 @@
             }
           }
         } @else if $page-position == 'first:right' {
-          @if  if-map-get($content-position, right) {
+          @if if-map-get($content-position, right) {
             @include position(if-map-get($content-position, right)) {
               @if head-or-foot($content-position) == 'head' {
                 padding-top: $runninghead-padding-top;
@@ -39,15 +39,15 @@
             }
           }
         } @else {
-          @include position($content-position) {
-            @if head-or-foot($content-position) == 'head' {
-              padding-top: $runninghead-padding-top;
-            } @else if head-or-foot($content-position) == 'foot' {
-              padding-bottom: $runningfoot-padding-bottom;
-            }
+            @include position($content-position) {
+              @if head-or-foot($content-position) == 'head' {
+                padding-top: $runninghead-padding-top;
+              } @else if head-or-foot($content-position) == 'foot' {
+                padding-bottom: $runningfoot-padding-bottom;
+              }
 
-            @include front-matter-page-number;
-          }
+              @include front-matter-page-number;
+            }
         }
       }
     }
@@ -60,7 +60,7 @@
       'back-matter:#{$page-position}' {
       @page #{$page-type} {
         @if $page-position == 'first:left' {
-          @if  if-map-get($content-position, left) {
+          @if if-map-get($content-position, left) {
             @include position(if-map-get($content-position, left)) {
               @if head-or-foot($content-position) == 'head' {
                 padding-top: $runninghead-padding-top;
@@ -72,7 +72,7 @@
             }
           }
         } @else if $page-position == 'first:right' {
-          @if  if-map-get($content-position, right) {
+          @if if-map-get($content-position, right) {
             @include position(if-map-get($content-position, right)) {
               @if head-or-foot($content-position) == 'head' {
                 padding-top: $runninghead-padding-top;
@@ -84,14 +84,16 @@
             }
           }
         } @else {
-          @include position($content-position) {
-            @if head-or-foot($content-position) == 'head' {
-              padding-top: $runninghead-padding-top;
-            } @else if head-or-foot($content-position) == 'foot' {
-              padding-bottom: $runningfoot-padding-bottom;
-            }
+          @if $content-position {
+            @include position($content-position) {
+              @if head-or-foot($content-position) == 'head' {
+                padding-top: $runninghead-padding-top;
+              } @else if head-or-foot($content-position) == 'foot' {
+                padding-bottom: $runningfoot-padding-bottom;
+              }
 
-            @include page-number;
+              @include page-number;
+            }
           }
         }
       }
@@ -118,100 +120,87 @@
   color: if-map-get($page-number-color, $type);
 }
 
-@mixin position($content-position) {
-  @if $content-position == '@bottom-center' {
-    @bottom-center {
-      @content;
+@mixin position($position) {
+  @if $position {
+    @if $position == '@top-left-corner' {
+      @top-left-corner {
+        @content;
+      }
     }
-  }
-
-  @if $content-position == '@bottom-right-corner' {
-    @bottom-right-corner {
-      @content;
+    @if $position == '@top-left' {
+      @top-left {
+        @content;
+      }
     }
-  }
-
-  @if $content-position == '@left-middle' {
-    @left-middle {
-      @content;
+    @if $position == '@top-center' {
+      @top-center {
+        @content;
+      }
     }
-  }
-
-  @if $content-position == '@right-middle' {
-    @right-middle {
-      @content;
+    @if $position == '@top-right' {
+      @top-right {
+        @content;
+      }
     }
-  }
-
-  @if $content-position == '@top-left-corner' {
-    @top-left-corner {
-      @content;
+    @if $position == '@top-right-corner' {
+      @top-right-corner {
+        @content;
+      }
     }
-  }
-
-  @if $content-position == '@top-right' {
-    @top-right {
-      @content;
-    }
-  }
-
-  @if $content-position == '@bottom-left-corner' {
-    @bottom-left-corner {
-      @content;
-    }
-  }
-
-  @if $content-position == '@bottom-right' {
-    @bottom-right {
-      @content;
-    }
-  }
-
-  @if $content-position == '@left-top' {
+    @if $position == "@left-top" {
       @left-top {
         @content;
       }
-  }
-
-  @if $content-position == '@right-top' {
-    @right-top {
-      @content;
     }
-  }
-
-  @if $content-position == '@top-left' {
-    @top-left {
-      @content;
+    @if $position == "@left-middle" {
+      @left-middle {
+        @content;
+      }
     }
-  }
-
-  @if $content-position == '@bottom-left' {
-    @bottom-left {
-      @content;
+    @if $position == "@left-bottom" {
+      @left-bottom {
+        @content;
+      }
     }
-  }
-
-  @if $content-position == '@left-bottom' {
-    @left-bottom {
-      @content;
+    @if $position == "@right-top" {
+      @right-top {
+        @content;
+      }
     }
-  }
-
-  @if $content-position == '@right-bottom' {
-    @right-bottom {
-      @content;
+    @if $position == "@right-middle" {
+      @right-middle {
+        @content;
+      }
     }
-  }
-
-  @if $content-position == '@top-center' {
-    @top-center {
-      @content;
+    @if $position == "@right-bottom" {
+      @right-bottom {
+        @content;
+      }
     }
-  }
-
-  @if $content-position == '@top-right-corner' {
-    @top-right-corner {
-      @content;
+    @if $position == '@bottom-left-corner' {
+      @bottom-left-corner {
+        @content;
+      }
+    }
+    @if $position == '@bottom-left' {
+      @bottom-left {
+        @content;
+      }
+    }
+    @if $position == '@bottom-center' {
+      @bottom-center {
+        @content;
+      }
+    }
+    @if $position == '@bottom-right' {
+      @bottom-right {
+        @content;
+      }
+    }
+    @if $position == '@bottom-right-corner' {
+      @bottom-right-corner {
+        @content;
+      }
     }
   }
 }
@@ -229,7 +218,7 @@
     'back-matter:#{$page-position}' {
     @page #{$page-type} {
       @if $page-position == 'first:left' {
-        @if  if-map-get($content-position, left) {
+        @if if-map-get($content-position, left) {
           @include position(if-map-get($content-position, left)) {
             padding-top: $runninghead-padding-top;
             font-family: $runninghead-left-font-family;
@@ -244,7 +233,7 @@
           }
         }
       } @else if $page-position == 'first:right' {
-        @if  if-map-get($content-position, right) {
+        @if if-map-get($content-position, right) {
           @include position(if-map-get($content-position, right)) {
             padding-top: $runninghead-padding-top;
             font-family: $runninghead-right-font-family;
@@ -302,7 +291,7 @@
     'back-matter:#{$page-position}' {
     @page #{$page-type} {
       @if $page-position == 'first:left' {
-        @if  if-map-get($content-position, left) {
+        @if if-map-get($content-position, left) {
           @include position(if-map-get($content-position, left)) {
             padding-bottom: $runningfoot-padding-bottom;
             font-family: $runningfoot-left-font-family;
@@ -317,7 +306,7 @@
           }
         }
       } @else if $page-position == 'first:right' {
-        @if  if-map-get($content-position, right) {
+        @if if-map-get($content-position, right) {
           @include position(if-map-get($content-position, right)) {
             padding-bottom: $runningfoot-padding-bottom;
             font-family: $runningfoot-right-font-family;

--- a/assets/styles/components/structure/_mixins.scss
+++ b/assets/styles/components/structure/_mixins.scss
@@ -119,100 +119,10 @@
 }
 
 @mixin position($content-position) {
-  @if $content-position == '@bottom-center' {
-    @bottom-center {
-      @content;
-    }
-  }
+  $position: str-replace($content-position, '@');
 
-  @if $content-position == '@bottom-right-corner' {
-    @bottom-right-corner {
-      @content;
-    }
-  }
-
-  @if $content-position == '@left-middle' {
-    @left-middle {
-      @content;
-    }
-  }
-
-  @if $content-position == '@right-middle' {
-    @right-middle {
-      @content;
-    }
-  }
-
-  @if $content-position == '@top-left-corner' {
-    @top-left-corner {
-      @content;
-    }
-  }
-
-  @if $content-position == '@top-right' {
-    @top-right {
-      @content;
-    }
-  }
-
-  @if $content-position == '@bottom-left-corner' {
-    @bottom-left-corner {
-      @content;
-    }
-  }
-
-  @if $content-position == '@bottom-right' {
-    @bottom-right {
-      @content;
-    }
-  }
-
-  @if $content-position == '@left-top' {
-      @left-top {
-        @content;
-      }
-  }
-
-  @if $content-position == '@right-top' {
-    @right-top {
-      @content;
-    }
-  }
-
-  @if $content-position == '@top-left' {
-    @top-left {
-      @content;
-    }
-  }
-
-  @if $content-position == '@bottom-left' {
-    @bottom-left {
-      @content;
-    }
-  }
-
-  @if $content-position == '@left-bottom' {
-    @left-bottom {
-      @content;
-    }
-  }
-
-  @if $content-position == '@right-bottom' {
-    @right-bottom {
-      @content;
-    }
-  }
-
-  @if $content-position == '@top-center' {
-    @top-center {
-      @content;
-    }
-  }
-
-  @if $content-position == '@top-right-corner' {
-    @top-right-corner {
-      @content;
-    }
+  @#{$position} {
+    @content;
   }
 }
 

--- a/assets/styles/components/structure/_mixins.scss
+++ b/assets/styles/components/structure/_mixins.scss
@@ -119,10 +119,100 @@
 }
 
 @mixin position($content-position) {
-  $position: str-replace($content-position, '@');
+  @if $content-position == '@bottom-center' {
+    @bottom-center {
+      @content;
+    }
+  }
 
-  @#{$position} {
-    @content;
+  @if $content-position == '@bottom-right-corner' {
+    @bottom-right-corner {
+      @content;
+    }
+  }
+
+  @if $content-position == '@left-middle' {
+    @left-middle {
+      @content;
+    }
+  }
+
+  @if $content-position == '@right-middle' {
+    @right-middle {
+      @content;
+    }
+  }
+
+  @if $content-position == '@top-left-corner' {
+    @top-left-corner {
+      @content;
+    }
+  }
+
+  @if $content-position == '@top-right' {
+    @top-right {
+      @content;
+    }
+  }
+
+  @if $content-position == '@bottom-left-corner' {
+    @bottom-left-corner {
+      @content;
+    }
+  }
+
+  @if $content-position == '@bottom-right' {
+    @bottom-right {
+      @content;
+    }
+  }
+
+  @if $content-position == '@left-top' {
+      @left-top {
+        @content;
+      }
+  }
+
+  @if $content-position == '@right-top' {
+    @right-top {
+      @content;
+    }
+  }
+
+  @if $content-position == '@top-left' {
+    @top-left {
+      @content;
+    }
+  }
+
+  @if $content-position == '@bottom-left' {
+    @bottom-left {
+      @content;
+    }
+  }
+
+  @if $content-position == '@left-bottom' {
+    @left-bottom {
+      @content;
+    }
+  }
+
+  @if $content-position == '@right-bottom' {
+    @right-bottom {
+      @content;
+    }
+  }
+
+  @if $content-position == '@top-center' {
+    @top-center {
+      @content;
+    }
+  }
+
+  @if $content-position == '@top-right-corner' {
+    @top-right-corner {
+      @content;
+    }
   }
 }
 

--- a/assets/styles/components/structure/_mixins.scss
+++ b/assets/styles/components/structure/_mixins.scss
@@ -16,7 +16,7 @@
       @page #{$page-type} {
         @if $page-position == 'first:left' {
           @if  if-map-get($content-position, left) {
-            #{if-map-get($content-position, left)} {
+            @include position(if-map-get($content-position, left)) {
               @if head-or-foot($content-position) == 'head' {
                 padding-top: $runninghead-padding-top;
               } @else if head-or-foot($content-position) == 'foot' {
@@ -28,7 +28,7 @@
           }
         } @else if $page-position == 'first:right' {
           @if  if-map-get($content-position, right) {
-            #{if-map-get($content-position, right)} {
+            @include position(if-map-get($content-position, right)) {
               @if head-or-foot($content-position) == 'head' {
                 padding-top: $runninghead-padding-top;
               } @else if head-or-foot($content-position) == 'foot' {
@@ -39,7 +39,7 @@
             }
           }
         } @else {
-          #{$content-position} {
+          @include position($content-position) {
             @if head-or-foot($content-position) == 'head' {
               padding-top: $runninghead-padding-top;
             } @else if head-or-foot($content-position) == 'foot' {
@@ -61,7 +61,7 @@
       @page #{$page-type} {
         @if $page-position == 'first:left' {
           @if  if-map-get($content-position, left) {
-            #{if-map-get($content-position, left)} {
+            @include position(if-map-get($content-position, left)) {
               @if head-or-foot($content-position) == 'head' {
                 padding-top: $runninghead-padding-top;
               } @else if head-or-foot($content-position) == 'foot' {
@@ -73,7 +73,7 @@
           }
         } @else if $page-position == 'first:right' {
           @if  if-map-get($content-position, right) {
-            #{if-map-get($content-position, right)} {
+            @include position(if-map-get($content-position, right)) {
               @if head-or-foot($content-position) == 'head' {
                 padding-top: $runninghead-padding-top;
               } @else if head-or-foot($content-position) == 'foot' {
@@ -84,7 +84,7 @@
             }
           }
         } @else {
-          #{$content-position} {
+          @include position($content-position) {
             @if head-or-foot($content-position) == 'head' {
               padding-top: $runninghead-padding-top;
             } @else if head-or-foot($content-position) == 'foot' {
@@ -118,6 +118,104 @@
   color: if-map-get($page-number-color, $type);
 }
 
+@mixin position($content-position) {
+  @if $content-position == '@bottom-center' {
+    @bottom-center {
+      @content;
+    }
+  }
+
+  @if $content-position == '@bottom-right-corner' {
+    @bottom-right-corner {
+      @content;
+    }
+  }
+
+  @if $content-position == '@left-middle' {
+    @left-middle {
+      @content;
+    }
+  }
+
+  @if $content-position == '@right-middle' {
+    @right-middle {
+      @content;
+    }
+  }
+
+  @if $content-position == '@top-left-corner' {
+    @top-left-corner {
+      @content;
+    }
+  }
+
+  @if $content-position == '@top-right' {
+    @top-right {
+      @content;
+    }
+  }
+
+  @if $content-position == '@bottom-left-corner' {
+    @bottom-left-corner {
+      @content;
+    }
+  }
+
+  @if $content-position == '@bottom-right' {
+    @bottom-right {
+      @content;
+    }
+  }
+
+  @if $content-position == '@left-top' {
+      @left-top {
+        @content;
+      }
+  }
+
+  @if $content-position == '@right-top' {
+    @right-top {
+      @content;
+    }
+  }
+
+  @if $content-position == '@top-left' {
+    @top-left {
+      @content;
+    }
+  }
+
+  @if $content-position == '@bottom-left' {
+    @bottom-left {
+      @content;
+    }
+  }
+
+  @if $content-position == '@left-bottom' {
+    @left-bottom {
+      @content;
+    }
+  }
+
+  @if $content-position == '@right-bottom' {
+    @right-bottom {
+      @content;
+    }
+  }
+
+  @if $content-position == '@top-center' {
+    @top-center {
+      @content;
+    }
+  }
+
+  @if $content-position == '@top-right-corner' {
+    @top-right-corner {
+      @content;
+    }
+  }
+}
+
 // Running Content
 /// @param {string} $page-position - The page position.
 /// @param {string|map} $content-position - The running content position.
@@ -132,7 +230,7 @@
     @page #{$page-type} {
       @if $page-position == 'first:left' {
         @if  if-map-get($content-position, left) {
-          #{if-map-get($content-position, left)} {
+          @include position(if-map-get($content-position, left)) {
             padding-top: $runninghead-padding-top;
             font-family: $runninghead-left-font-family;
             font-size: $runninghead-left-font-size;
@@ -147,7 +245,7 @@
         }
       } @else if $page-position == 'first:right' {
         @if  if-map-get($content-position, right) {
-          #{if-map-get($content-position, right)} {
+          @include position(if-map-get($content-position, right)) {
             padding-top: $runninghead-padding-top;
             font-family: $runninghead-right-font-family;
             font-size: $runninghead-right-font-size;
@@ -161,7 +259,7 @@
           }
         }
       } @else {
-        #{$content-position} {
+        @include position($content-position) {
           padding-top: $runninghead-padding-top;
 
           @if $page-position == 'left' {
@@ -205,7 +303,7 @@
     @page #{$page-type} {
       @if $page-position == 'first:left' {
         @if  if-map-get($content-position, left) {
-          #{if-map-get($content-position, left)} {
+          @include position(if-map-get($content-position, left)) {
             padding-bottom: $runningfoot-padding-bottom;
             font-family: $runningfoot-left-font-family;
             font-size: $runningfoot-left-font-size;
@@ -220,7 +318,7 @@
         }
       } @else if $page-position == 'first:right' {
         @if  if-map-get($content-position, right) {
-          #{if-map-get($content-position, right)} {
+          @include position(if-map-get($content-position, right)) {
             padding-bottom: $runningfoot-padding-bottom;
             font-family: $runningfoot-right-font-family;
             font-size: $runningfoot-right-font-size;
@@ -234,7 +332,7 @@
           }
         }
       } @else {
-        #{$content-position} {
+        @include position($content-position) {
           padding-bottom: $runningfoot-padding-bottom;
 
           @if $page-position == 'left' {
@@ -274,7 +372,7 @@
     @if $numbering-position == $running-content-position {
       @if $page-position != 'first' {
         @page #{$page-type}:#{$page-position} {
-          #{$running-content-position} {
+          @include position($running-content-position) {
             @if $page-position == 'left' {
               @if $running-content-position == '@top-right'
                 or $running-content-position == '@top-right-corner'
@@ -298,7 +396,7 @@
         }
       } @else {
         @page #{$page-type}:first:right {
-          #{if-map-get($running-content-position, right)} {
+          @include position(if-map-get($running-content-position, right)) {
             @if if-map-get($running-content-position, right) == '@bottom-left'
               or if-map-get($running-content-position, right) == '@bottom-left-corner'
               or if-map-get($running-content-position, right) == '@left-bottom' {
@@ -310,7 +408,7 @@
         }
 
         @page #{$page-type}:first:left {
-          #{if-map-get($running-content-position, left)} {
+          @include position(if-map-get($running-content-position, left)) {
             @if if-map-get($running-content-position, left) == '@bottom-right'
               or if-map-get($running-content-position, left) == '@bottom-right-corner'
               or if-map-get($running-content-position, left) == '@right-bottom' {
@@ -324,7 +422,7 @@
     } @else {
       @if $page-position != 'first' {
         @page #{$page-type}:#{$page-position} {
-          #{$running-content-position} {
+          @include position($running-content-position) {
             @if $page-position == 'left' {
               content: if-map-get($left-running-content, $page-type);
             } @else if $page-position == 'right' {
@@ -332,7 +430,7 @@
             }
           }
 
-          #{$numbering-position} {
+          @include position($numbering-position) {
             @if $page-position == 'left' {
               content: if-map-get($left-page-number, $page-type);
             } @else if $page-position == 'right' {
@@ -343,19 +441,19 @@
         }
       } @else {
         @page #{$page-type}:first:right {
-          #{if-map-get($running-content-position, right)} {
+          @include position(if-map-get($running-content-position, right)) {
             content: if-map-get($right-running-content, $page-type);
           }
-          #{if-map-get($numbering-position, right)} {
+          @include position(if-map-get($numbering-position, right)) {
             content: if-map-get($right-page-number, $page-type);
           }
         }
 
         @page #{$page-type}:first:left {
-          #{if-map-get($running-content-position, left)} {
+          @include position(if-map-get($running-content-position, left)) {
             content: if-map-get($left-running-content, $page-type);
           }
-          #{if-map-get($numbering-position, left)} {
+          @include position(if-map-get($numbering-position, left)) {
             content: if-map-get($left-page-number, $page-type);
           }
         }
@@ -365,7 +463,7 @@
     @if $numbering-position {
       @if $page-position != 'first' {
         @page #{$page-type}:#{$page-position} {
-          #{$numbering-position} {
+          @include position($numbering-position) {
             @if $page-position == 'left' {
               content: if-map-get($left-page-number, $page-type);
             } @else if $page-position == 'right' {
@@ -375,13 +473,13 @@
         }
       } @else {
         @page #{$page-type}:first:right {
-          #{if-map-get($numbering-position, right)} {
+          @include position(if-map-get($numbering-position, right)) {
             content: if-map-get($right-page-number, $page-type);
           }
         }
 
         @page #{$page-type}:first:left {
-          #{if-map-get($numbering-position, left)} {
+          @include position(if-map-get($numbering-position, left)) {
             content: if-map-get($left-page-number, $page-type);
           }
         }
@@ -391,7 +489,7 @@
     @if $running-content-position {
       @if $page-position != 'first' {
         @page #{$page-type}:#{$page-position} {
-          #{$running-content-position} {
+          @include position($running-content-position) {
             @if $page-position == 'left' {
               content: if-map-get($left-running-content, $page-type);
             } @else if $page-position == 'right' {
@@ -401,13 +499,13 @@
         }
       } @else {
         @page #{$page-type}:first:right {
-          #{if-map-get($running-content-position, right)} {
+          @include position(if-map-get($running-content-position, right)) {
             content: if-map-get($right-running-content, $page-type);
           }
         }
 
         @page #{$page-type}:first:left {
-          #{if-map-get($running-content-position, left)} {
+          @include position(if-map-get($running-content-position, left)) {
             content: if-map-get($left-running-content, $page-type);
           }
         }

--- a/assets/styles/components/structure/_mixins.scss
+++ b/assets/styles/components/structure/_mixins.scss
@@ -17,9 +17,9 @@
         @if $page-position == 'first:left' {
           @if if-map-get($content-position, left) {
             @include position(if-map-get($content-position, left)) {
-              @if head-or-foot($content-position) == 'head' {
+              @if head-or-foot(if-map-get($content-position, left)) == 'head' {
                 padding-top: $runninghead-padding-top;
-              } @else if head-or-foot($content-position) == 'foot' {
+              } @else if head-or-foot(if-map-get($content-position, left)) == 'foot' {
                 padding-bottom: $runningfoot-padding-bottom;
               }
 
@@ -29,9 +29,9 @@
         } @else if $page-position == 'first:right' {
           @if if-map-get($content-position, right) {
             @include position(if-map-get($content-position, right)) {
-              @if head-or-foot($content-position) == 'head' {
+              @if head-or-foot(if-map-get($content-position, right)) == 'head' {
                 padding-top: $runninghead-padding-top;
-              } @else if head-or-foot($content-position) == 'foot' {
+              } @else if head-or-foot(if-map-get($content-position, right)) == 'foot' {
                 padding-bottom: $runningfoot-padding-bottom;
               }
 
@@ -62,9 +62,9 @@
         @if $page-position == 'first:left' {
           @if if-map-get($content-position, left) {
             @include position(if-map-get($content-position, left)) {
-              @if head-or-foot($content-position) == 'head' {
+              @if head-or-foot(if-map-get($content-position, left)) == 'head' {
                 padding-top: $runninghead-padding-top;
-              } @else if head-or-foot($content-position) == 'foot' {
+              } @else if head-or-foot(if-map-get($content-position, left)) == 'foot' {
                 padding-bottom: $runningfoot-padding-bottom;
               }
 
@@ -74,9 +74,9 @@
         } @else if $page-position == 'first:right' {
           @if if-map-get($content-position, right) {
             @include position(if-map-get($content-position, right)) {
-              @if head-or-foot($content-position) == 'head' {
+              @if head-or-foot(if-map-get($content-position, right)) == 'head' {
                 padding-top: $runninghead-padding-top;
-              } @else if head-or-foot($content-position) == 'foot' {
+              } @else if head-or-foot(if-map-get($content-position, right)) == 'foot' {
                 padding-bottom: $runningfoot-padding-bottom;
               }
 

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,6 @@
 		]
 	},
 	"require-dev": {
-		"scssphp/scssphp": "~1.1"
+		"scssphp/scssphp": "^1.11"
 	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0e5ad88ba90ffa439c58828671887da6",
+    "content-hash": "fc76f0dba56bfdda826f4f2d5ce816e8",
     "packages": [],
     "packages-dev": [
         {
             "name": "scssphp/scssphp",
-            "version": "1.1.1",
+            "version": "v1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/scssphp/scssphp.git",
-                "reference": "824e4cec10b2bfa88eec5dac23991cb9106622c1"
+                "reference": "33749d12c2569bb24071f94e9af828662dabb068"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/scssphp/scssphp/zipball/824e4cec10b2bfa88eec5dac23991cb9106622c1",
-                "reference": "824e4cec10b2bfa88eec5dac23991cb9106622c1",
+                "url": "https://api.github.com/repos/scssphp/scssphp/zipball/33749d12c2569bb24071f94e9af828662dabb068",
+                "reference": "33749d12c2569bb24071f94e9af828662dabb068",
                 "shasum": ""
             },
             "require": {
@@ -27,15 +27,30 @@
                 "php": ">=5.6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.3",
+                "bamarni/composer-bin-plugin": "^1.4",
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.3 || ^9.4",
+                "sass/sass-spec": "*",
                 "squizlabs/php_codesniffer": "~3.5",
-                "twbs/bootstrap": "~4.3",
+                "symfony/phpunit-bridge": "^5.1",
+                "thoughtbot/bourbon": "^7.0",
+                "twbs/bootstrap": "~5.0",
+                "twbs/bootstrap4": "4.6.1",
                 "zurb/foundation": "~6.5"
+            },
+            "suggest": {
+                "ext-iconv": "Can be used as fallback when ext-mbstring is not available",
+                "ext-mbstring": "For best performance, mbstring should be installed as it is faster than ext-iconv"
             },
             "bin": [
                 "bin/pscss"
             ],
             "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "forward-command": false,
+                    "bin-links": false
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "ScssPhp\\ScssPhp\\": "src/"
@@ -68,9 +83,9 @@
             ],
             "support": {
                 "issues": "https://github.com/scssphp/scssphp/issues",
-                "source": "https://github.com/scssphp/scssphp/tree/1.1.1"
+                "source": "https://github.com/scssphp/scssphp/tree/v1.11.0"
             },
-            "time": "2020-06-04T17:30:40+00:00"
+            "time": "2022-09-02T21:24:55+00:00"
         }
     ],
     "aliases": [],
@@ -80,5 +95,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,13 @@
     "rules": {
       "no-descending-specificity": null,
       "no-duplicate-at-import-rules": null,
-      "scss/no-global-function-names": null
+      "scss/no-global-function-names": null,
+      "scss/at-rule-no-unknown": [
+        true,
+        {
+            "ignoreAtRules": ["#{$position}", "top", "footnotes", "bottom", "page:blank", "page:left", "page:right"]
+        }
+      ]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,13 +41,7 @@
     "rules": {
       "no-descending-specificity": null,
       "no-duplicate-at-import-rules": null,
-      "scss/no-global-function-names": null,
-      "scss/at-rule-no-unknown": [
-        true,
-        {
-            "ignoreAtRules": ["#{$position}", "top", "footnotes", "bottom", "page:blank", "page:left", "page:right"]
-        }
-      ]
+      "scss/no-global-function-names": null
     }
   }
 }


### PR DESCRIPTION
### Context for the issue

When a book author selects the position for running content in PDF outputs, a complex series of rules must be applied. For example, if one indicates that:

- the page number on the first page of a chapter should be on the bottom outside corner
- the page number on the remaining pages of the chapter should be on the bottom center 
- chapters can start on either the left or the right page

…the CSS needs to respond appropriately:

- styling the `@bottom-left` area when a chapter begins on the left page
- styling the `@bottom-right` area when a chapter begins on the right page
- styling the `@bottom-center` area on all other left/right pages in the chapter.

In all earlier implementations of Buckram, such rules were composed using the following syntax within a few different mixins:

```scss
#{$content-position} {
	// Rules go here.
}
```

`$content-position` would be something like `@bottom-center` and the `#{}` syntax is Sass's method of string interpolation.

HOWEVER. That's not valid Sass. You can't (as far as I can tell) generate an entire selector from an interpolation rule. Trying to do this with `@bottom-center` throws a critical error and the Sass fails to compile. A bug in SCSSPHP <= 1.1.1 was allowing this non-standard SCSS to compile, but the bug was resolved in SCSSPHP 1.2 which broke Buckram's SCSS.

### What this PR does

Instead of using interpolation, I've created [a helper mixin called `position`](https://github.com/pressbooks/buckram/blob/5dbc71c13db619066d5f9b6eb62b9d6a97dd481c/assets/styles/components/structure/_mixins.scss#L121) which, when passed a position value such as `@bottom-left`, `@top-left`, etc, will wrap content in it. So for example:

```scss
@include position('@top-left') {
	text-align: left;
}
```

Compiles to:

```css
@top-left {
	text-align: left;
}
```

This resolves the incompatibility with SCSSPHP (and the SCSS standard) and allows SCSSPHP to be safely updated to the current version.

### Testing

To verify that the page structure still works as expected, I completed the following tests:

1. Using PHP 7.4 and SCSSPHP 1.1.1 and the `dev` version of Buckram, I ran:

```bash
vendor/bin/pscss tests/source/styles/prince-toc-left.scss > before.css
```

2. Using PHP 8.0 and SCSSPHP 1.11.0 and this PR version of Buckram, I ran

```bash
vendor/bin/pscss tests/source/styles/prince-toc-left.scss > after.css
```

You can compare the output files in the [attached Zip archive](https://github.com/pressbooks/buckram/files/10261458/outputs.zip).

### Related issues

Resolves pressbooks/pressbooks#2281.
