### PR TITLE
fix: update gitignore to avoid publish config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,7 @@ typings/
 
 docs
 vendor
+
+# IDEs
+.idea
+.vscode


### PR DESCRIPTION
This PR prevents publishing unwanted files if opened in an editor