### PR TITLE
fix: use text-sidebar width variable

### DIFF
--- a/assets/styles/components/specials/_textboxes.scss
+++ b/assets/styles/components/specials/_textboxes.scss
@@ -212,7 +212,7 @@
     margin-inside: $textbox-sidebar-margin-inside;
   }
 
-  max-width: 25%;
+  max-width: $textbox-sidebar-max-width;
 }
 
 @if $type == 'epub' {


### PR DESCRIPTION
This change adds the variable $textbox-sidebar-max-width to the margin inside. This change should not impact existing themes because the default for the variable is 25% but should be checked. It would only effect a theme that has a value for $textbox-sidebar-max-width which would have previously done nothing.

Fix for https://github.com/pressbooks/buckram/issues/327