### PR TITLE
fix: add textbox--sidebar to list of classes with indent fix

### DIFF
--- a/assets/styles/components/elements/_paragraphs.scss
+++ b/assets/styles/components/elements/_paragraphs.scss
@@ -199,23 +199,6 @@
       hyphens: none;
     }
 
-    // When paragraphs follow a floated element, make sure indents work as expected.
-    // NOTE: this should only happen when paragraph separators = indent.
-
-    .wp-caption.alignleft + p,
-    .wp-nocaption.alignleft + p,
-    .wp-caption.alignright + p,
-    .wp-nocaption.alignright + p,
-    .float-top + p,
-    .float-bottom + p,
-    .pullquote + p,
-    .pullquote-right + p,
-    .pullquote-left + p,
-    .pullquote-outside + p,
-    .sidebar + p {
-      margin-top: $para-margin-top;
-      text-indent: $para-indent;
-    }
 
     // Hanging Indents
     .hanging-indent {

--- a/assets/styles/components/elements/_paragraphs.scss
+++ b/assets/styles/components/elements/_paragraphs.scss
@@ -62,7 +62,8 @@
   .pullquote--outside + p,
   .pullquote-inside + p,
   .pullquote--inside + p,
-  .sidebar + p {
+  .sidebar + p,
+  .textbox--sidebar + p {
     margin-top: $para-margin-top;
     text-indent: $para-indent;
   }


### PR DESCRIPTION
There is an existing fix in Buckram to correct indent errors caused by floating images and divs. This fix adds the class textbox--sidebar to the list of classes along with floated images and pull quotes and should fix apply the fix to standard, shaded and educational boxes that are floated to the sidebar. 

https://github.com/pressbooks/pressbooks/issues/3399
