### PR TITLE
fix: allow glossary terms to be copy/pasted by Firefox users

### DIFF
--- a/assets/styles/components/specials/_glossaryterms.scss
+++ b/assets/styles/components/specials/_glossaryterms.scss
@@ -8,4 +8,5 @@
 
 .glossary-term {
   font-weight: bold;
+  user-select: text;
 }


### PR DESCRIPTION
Fix for https://github.com/pressbooks/buckram/issues/372