### PR TITLE
fix: nested paragraphs font size in tables

### DIFF
--- a/assets/styles/components/elements/_tables.scss
+++ b/assets/styles/components/elements/_tables.scss
@@ -297,6 +297,12 @@
       td img.alignright {
         float: right;
       }
+
+      th,td {
+        p {
+          font-size: inherit;
+        }
+      }
     }
 
     table,


### PR DESCRIPTION
This pull request includes a small change to the `assets/styles/components/elements/_tables.scss` file. The change ensures that the font size of paragraphs within table headers (`th`) and table data cells (`td`) inherits the font size from its parent element.

* [`assets/styles/components/elements/_tables.scss`](diffhunk://#diff-b753d04ec8abaec54350c68987838e1555a1647c9a2b9bb4d1250d5b0e6e43a6R300-R305): Added a rule to make the font size of paragraphs within `th` and `td` elements inherit from their parent.

address https://github.com/pressbooks/pressbooks-book/issues/786

The em relative sizes inherits the size from the parent so every `<p>` inside of a table always will have a smaller size than non paragraphed texts inside of table rows

```mermaid
graph TD
    subgraph After_Fix
        A1[Document: 1em = 16px] -->|"font-size: inherit"| B1["p in table > td/th: 0.9em = 14.4px"]
        A1 -->|"font-size: 0.9em"| C1[" table > td/th: 0.9em = 14.4px"]
    end
    
    subgraph Before_Fix
        A2[Document: 1em = 16px] -->|"font-size: 0.9em"| C2[" table > td/th: 0.9em = 14.4px"]
        C2 -->|"font-size: 0.9em"| B2["p in table > td/th: 0.81em = 13.0px"]
    end
    
    style A1 fill:#d4f1f9,stroke:#333
    style A2 fill:#d4f1f9,stroke:#333
    style C1 fill:#ffecb3,stroke:#333
    style C2 fill:#ffecb3,stroke:#333
    style B1 fill:#c8e6c9,stroke:#333
    style B2 fill:#ffcdd2,stroke:#333
```

### How to test

Change your desired theme (pressbooks-book)'s `package.json` to point to this branch 

```json
{
	"dependencies": {
		"aetna": "^1.0.0",
		"buckram": "github:pressbooks/buckram#fix/autop-size",
		"details-element-polyfill": "^2.4.0",
		"lity": "^2.4.0",
		"sharer.js": "^0.5.1",
		"spinkit": "^2.0.1"
	}
}
```

> npm i && npm run build

Regenerate your book stylesheet in the diagnostics page and observe the desired result 
