### PR TITLE
fix: inherit line-height

### DIFF
--- a/assets/styles/components/elements/_tables.scss
+++ b/assets/styles/components/elements/_tables.scss
@@ -301,6 +301,7 @@
       th,td {
         p {
           font-size: inherit;
+          line-height: inherit;
         }
       }
     }


### PR DESCRIPTION
This will solve remaining font styling issues on tables see #375 for more details

### How to test

Change your desired theme (pressbooks-book)'s `package.json` to point to this branch 

```json
{
	"dependencies": {
		"aetna": "^1.0.0",
		"buckram": "github:pressbooks/buckram#fix/tables-text-style",
		"details-element-polyfill": "^2.4.0",
		"lity": "^2.4.0",
		"sharer.js": "^0.5.1",
		"spinkit": "^2.0.1"
	}
}
```

> npm i && npm run build

Regenerate your book stylesheet in the diagnostics page and observe the desired result 