### PR TITLE
fix: remove usage of border color variable in shorthand

### DIFF
--- a/assets/styles/components/elements/_blockquotes.scss
+++ b/assets/styles/components/elements/_blockquotes.scss
@@ -17,7 +17,8 @@
     padding: if-map-get($blockquote-padding-top, $type) if-map-get($blockquote-padding-right, $type) if-map-get($blockquote-padding-bottom, $type) if-map-get($blockquote-padding-left, $type);
     letter-spacing: if-map-get($blockquote-letter-spacing, $type);
     word-spacing: if-map-get($blockquote-word-spacing, $type);
-    border-left: if-map-get($blockquote-border-left-width, $type) $blockquote-border-left-style $blockquote-border-left-color;
+    border-left: if-map-get($blockquote-border-left-width, $type) $blockquote-border-left-style;
+    border-left-color: $blockquote-border-left-color;
     @if $type == 'prince' {
       line-height: $blockquote-line-height;
     }
@@ -71,7 +72,8 @@
     padding: if-map-get($blockquote-padding-top, $type) if-map-get($blockquote-padding-right, $type) if-map-get($blockquote-padding-bottom, $type) if-map-get($blockquote-padding-left, $type);
     letter-spacing: if-map-get($blockquote-letter-spacing, $type);
     word-spacing: if-map-get($blockquote-word-spacing, $type);
-    border-left: if-map-get($blockquote-border-left-width, $type) $blockquote-border-left-style $blockquote-border-left-color;
+    border-left: if-map-get($blockquote-border-left-width, $type) $blockquote-border-left-style;
+    border-left-color: $blockquote-border-left-color;
     line-height: $blockquote-line-height;
     text-align: $blockquote-align;
   }

--- a/assets/styles/components/elements/_headings.scss
+++ b/assets/styles/components/elements/_headings.scss
@@ -10,7 +10,8 @@
 
 @mixin heading($heading) {
   #{$heading} {
-    border-bottom: map-get($heading-border-bottom-style-map, $heading) if-map-get(map-get($heading-border-bottom-width-map, $heading), $type) if-map-get(map-get($heading-border-bottom-color-map, $heading), $type);
+    border-bottom: map-get($heading-border-bottom-style-map, $heading) if-map-get(map-get($heading-border-bottom-width-map, $heading), $type);
+    border-bottom-color: if-map-get(map-get($heading-border-bottom-color-map, $heading), $type);
     margin-top: if-map-get(map-get($heading-margin-top-map, $heading), $type);
     margin-bottom: if-map-get(map-get($heading-margin-bottom-map, $heading), $type);
     padding-bottom: if-map-get(map-get($heading-padding-bottom-map, $heading), $type);

--- a/assets/styles/components/elements/_tables.scss
+++ b/assets/styles/components/elements/_tables.scss
@@ -34,10 +34,11 @@
 
     text-align: $table-align;
     border-collapse: collapse;
-    border-top: $table-border-width solid if-map-get($line-color-1, $type);
-    border-right: if-map-get($table-border-right-width, $type) if-map-get($table-border-right-style, $type) if-map-get($line-color-1, $type);
-    border-bottom: $table-border-width solid if-map-get($line-color-1, $type);
-    border-left: if-map-get($table-border-left-width, $type) if-map-get($table-border-left-style, $type) if-map-get($line-color-1, $type);
+    border-color: if-map-get($line-color-1, $type);
+    border-top: $table-border-width solid;
+    border-right: if-map-get($table-border-right-width, $type) if-map-get($table-border-right-style, $type);
+    border-bottom: $table-border-width solid;
+    border-left: if-map-get($table-border-left-width, $type) if-map-get($table-border-left-style, $type);
 
     p {
       text-align: $table-align;
@@ -56,8 +57,8 @@
     }
 
     &.lines tr {
-      border-top: $table-border-width solid if-map-get($line-color-1, $type);
-      border-bottom: $table-border-width solid if-map-get($line-color-1, $type);
+      border-top: $table-border-width solid;
+      border-bottom: $table-border-width solid;
       border-color: if-map-get($line-color-1, $type);
     }
 
@@ -81,7 +82,7 @@
 
     &.border {
       border: $table-border-width solid;
-      border-color: if-map-get($line-color-1, $type); // This value can be "initial" incompatible with border shorthand
+      border-color: if-map-get($line-color-1, $type);
     }
 
     &.no-border,
@@ -105,7 +106,7 @@
     &.grid tfoot,
     &.grid thead {
       border: 1px solid;
-      border-color: if-map-get($line-color-1, $type); // This value can be "initial" incompatible with border shorthand
+      border-color: if-map-get($line-color-1, $type);
     }
 
     &.alignleft {
@@ -158,15 +159,16 @@
 
     text-align: $table-th-align;
     vertical-align: $table-th-vertical-align;
-    border-top: if-map-get($table-th-border-top-width, $type) if-map-get($table-th-border-top-style, $type) if-map-get($line-color-1, $type);
-    border-right: if-map-get($table-th-border-right-width, $type) if-map-get($table-th-border-right-style, $type) if-map-get($line-color-1, $type);
-    border-bottom: if-map-get($table-th-border-bottom-width, $type) if-map-get($table-th-border-bottom-style, $type) if-map-get($line-color-1, $type);
-    border-left: if-map-get($table-th-border-left-width, $type) if-map-get($table-th-border-left-style, $type) if-map-get($line-color-1, $type);
+    border-color: if-map-get($line-color-1, $type);
+    border-top: if-map-get($table-th-border-top-width, $type) if-map-get($table-th-border-top-style, $type);
+    border-right: if-map-get($table-th-border-right-width, $type) if-map-get($table-th-border-right-style, $type);
+    border-bottom: if-map-get($table-th-border-bottom-width, $type) if-map-get($table-th-border-bottom-style, $type);
+    border-left: if-map-get($table-th-border-left-width, $type) if-map-get($table-th-border-left-style, $type);
   }
 
   td {
     border: if-map-get($table-td-border-width, $type) if-map-get($table-td-border-style, $type);
-    border-color: if-map-get($line-color-1, $type); // This value can be "initial" incompatible with border shorthand
+    border-color: if-map-get($line-color-1, $type);
     padding: $table-td-padding-top $table-td-padding-right $table-td-padding-bottom $table-td-padding-left;
     @if $type == 'prince' {
       line-height: $table-td-line-height;
@@ -177,8 +179,9 @@
   }
 
   tr {
-    border-top: if-map-get($table-tr-border-top-width, $type) if-map-get($table-tr-border-top-style, $type) if-map-get($line-color-1, $type);
-    border-bottom: if-map-get($table-tr-border-bottom-width, $type) if-map-get($table-tr-border-bottom-style, $type) if-map-get($line-color-1, $type);
+    border-top: if-map-get($table-tr-border-top-width, $type) if-map-get($table-tr-border-top-style, $type);
+    border-bottom: if-map-get($table-tr-border-bottom-width, $type) if-map-get($table-tr-border-bottom-style, $type);
+    border-color: if-map-get($line-color-1, $type);
   }
 } @else {
   .front-matter,
@@ -198,8 +201,8 @@
       line-height: $table-line-height;
       text-align: $table-align;
       border-collapse: collapse;
-      border-top: $table-border-width solid if-map-get($line-color-1, $type);
-      border-bottom: $table-border-width solid if-map-get($line-color-1, $type);
+      border-top: $table-border-width solid;
+      border-bottom: $table-border-width solid;
       border-color: if-map-get($line-color-1, $type);
 
       p {
@@ -217,8 +220,8 @@
       }
 
       &.lines tr {
-        border-top: $table-border-width solid if-map-get($line-color-1, $type);
-        border-bottom: $table-border-width solid if-map-get($line-color-1, $type);
+        border-top: $table-border-width solid;
+        border-bottom: $table-border-width solid;
         border-color: if-map-get($line-color-1, $type);
       }
 
@@ -242,7 +245,7 @@
 
       &.border {
         border: $table-border-width solid;
-        border-color: if-map-get($line-color-1, $type); // This value can be "initial" incompatible with border shorthand
+        border-color: if-map-get($line-color-1, $type);
       }
 
       &.no-border,
@@ -266,7 +269,7 @@
       &.grid tfoot,
       &.grid thead {
         border: 1px solid;
-        border-color: if-map-get($line-color-1, $type); // This value can be "initial" incompatible with border shorthand
+        border-color: if-map-get($line-color-1, $type);
       }
 
       &.alignleft {
@@ -317,8 +320,9 @@
       line-height: $table-th-line-height;
       text-align: $table-th-align;
       vertical-align: middle;
-      border-top: if-map-get($table-th-border-top-width, $type) if-map-get($table-th-border-top-style, $type) if-map-get($line-color-1, $type);
-      border-bottom: if-map-get($table-th-border-bottom-width, $type) if-map-get($table-th-border-bottom-style, $type) if-map-get($line-color-1, $type);
+      border-color: if-map-get($line-color-1, $type);
+      border-top: if-map-get($table-th-border-top-width, $type) if-map-get($table-th-border-top-style, $type);
+      border-bottom: if-map-get($table-th-border-bottom-width, $type) if-map-get($table-th-border-bottom-style, $type);
     }
 
     td {
@@ -327,12 +331,13 @@
       text-align: $table-td-align;
       vertical-align: middle;
       border: if-map-get($table-td-border-width, $type) if-map-get($table-td-border-style, $type);
-      border-color: if-map-get($line-color-1, $type); // This value can be "initial" incompatible with border shorthand
+      border-color: if-map-get($line-color-1, $type);
     }
 
     tr {
-      border-top: if-map-get($table-tr-border-top-width, $type) if-map-get($table-tr-border-top-style, $type) if-map-get($line-color-1, $type);
-      border-bottom: if-map-get($table-tr-border-bottom-width, $type) if-map-get($table-tr-border-bottom-style, $type) if-map-get($line-color-1, $type);
+      border-color: if-map-get($line-color-1, $type);
+      border-top: if-map-get($table-tr-border-top-width, $type) if-map-get($table-tr-border-top-style, $type);
+      border-bottom: if-map-get($table-tr-border-bottom-width, $type) if-map-get($table-tr-border-bottom-style, $type);
     }
   }
 }

--- a/assets/styles/components/pages/_titles.scss
+++ b/assets/styles/components/pages/_titles.scss
@@ -39,7 +39,8 @@
   word-spacing: $title-title-word-spacing;
   text-align: $title-title-align;
   text-transform: $title-title-text-transform;
-  border-bottom: if-map-get($title-title-border-bottom-width, $type) $title-title-border-bottom-style if-map-get($title-title-border-bottom-color, $type);
+  border-bottom: if-map-get($title-title-border-bottom-width, $type) $title-title-border-bottom-style;
+  border-bottom-color: if-map-get($title-title-border-bottom-color, $type);
   padding-bottom: if-map-get($title-title-padding-bottom, $type);
   @if $type == 'prince' {
     prince-bookmark-level: none;
@@ -76,7 +77,8 @@
   word-spacing: $title-subtitle-word-spacing;
   text-align: $title-subtitle-align;
   text-transform: $title-subtitle-text-transform;
-  border-bottom: if-map-get($title-subtitle-border-bottom-width, $type) $title-subtitle-border-bottom-style if-map-get($title-subtitle-border-bottom-color, $type);
+  border-bottom: if-map-get($title-subtitle-border-bottom-width, $type) $title-subtitle-border-bottom-style;
+  border-bottom-color: if-map-get($title-subtitle-border-bottom-color, $type);
   padding-bottom: if-map-get($title-subtitle-padding-bottom, $type);
   @if $type != 'epub' {
     line-height: if-map-get($title-subtitle-line-height, $type);
@@ -97,7 +99,8 @@
   text-align: $title-author-align;
   text-transform: $title-author-text-transform;
   text-indent: 0;
-  border-bottom: if-map-get($title-author-border-bottom-width, $type) $title-author-border-bottom-style if-map-get($title-author-border-bottom-color, $type);
+  border-bottom: if-map-get($title-author-border-bottom-width, $type) $title-author-border-bottom-style;
+  border-bottom-color: if-map-get($title-author-border-bottom-color, $type);
   padding-bottom: if-map-get($title-author-padding-bottom, $type);
   @if $type != 'epub' {
     line-height: if-map-get($title-author-line-height, $type);
@@ -133,7 +136,8 @@ div.publisher-logo {
   text-align: $title-publisher-align;
   text-transform: $title-publisher-text-transform;
   text-indent: 0;
-  border-bottom: if-map-get($title-publisher-border-bottom-width, $type) $title-publisher-border-bottom-style if-map-get($title-publisher-border-bottom-color, $type);
+  border-bottom: if-map-get($title-publisher-border-bottom-width, $type) $title-publisher-border-bottom-style;
+  border-bottom-color: if-map-get($title-publisher-border-bottom-color, $type);
   padding-bottom: if-map-get($title-publisher-padding-bottom, $type);
 }
 
@@ -156,7 +160,8 @@ div.publisher-logo {
   text-align: $title-publisher-city-align;
   text-transform: $title-publisher-city-text-transform;
   text-indent: 0;
-  border-bottom: if-map-get($title-publisher-city-border-bottom-width, $type) $title-publisher-city-border-bottom-style if-map-get($title-publisher-city-border-bottom-color, $type);
+  border-bottom: if-map-get($title-publisher-city-border-bottom-width, $type) $title-publisher-city-border-bottom-style;
+  border-bottom-color: if-map-get($title-publisher-city-border-bottom-color, $type);
   padding-bottom: if-map-get($title-publisher-city-padding-bottom, $type);
 }
 

--- a/assets/styles/components/section-titles/_back-matter.scss
+++ b/assets/styles/components/section-titles/_back-matter.scss
@@ -30,7 +30,8 @@
 
       text-align: $back-matter-title-align;
       text-transform: $back-matter-title-text-transform;
-      border-bottom: if-map-get($back-matter-title-border-bottom-width, $type) $back-matter-title-border-bottom-style if-map-get($back-matter-title-border-bottom-color, $type);
+      border-bottom: if-map-get($back-matter-title-border-bottom-width, $type) $back-matter-title-border-bottom-style;
+      border-bottom-color: if-map-get($back-matter-title-border-bottom-color, $type);
       padding-bottom: if-map-get($back-matter-title-padding-bottom, $type);
       letter-spacing: if-map-get($back-matter-title-letter-spacing, $type);
       word-spacing: if-map-get($back-matter-title-word-spacing, $type);

--- a/assets/styles/components/section-titles/_chapters.scss
+++ b/assets/styles/components/section-titles/_chapters.scss
@@ -9,7 +9,8 @@
     margin: if-map-get($section-header-margin-top, $type) if-map-get($section-header-margin-right, $type) if-map-get($section-header-margin-bottom, $type) if-map-get($section-header-margin-left, $type);
 
     .chapter-title {
-      border-bottom: if-map-get($chapter-title-border-bottom-width, $type) $chapter-title-border-bottom-style if-map-get($chapter-title-border-bottom-color, $type);
+      border-bottom: if-map-get($chapter-title-border-bottom-width, $type) $chapter-title-border-bottom-style;
+      border-bottom-color: if-map-get($chapter-title-border-bottom-color, $type);
       padding-bottom: if-map-get($chapter-title-padding-bottom, $type);
       display: $chapter-title-display;
       margin: if-map-get($chapter-title-margin-top, $type) if-map-get($chapter-title-margin-right, $type) 0 if-map-get($chapter-title-margin-left, $type);
@@ -43,7 +44,8 @@
     }
 
     .chapter-number {
-      border-bottom: if-map-get($chapter-number-border-bottom-width, $type) $chapter-number-border-bottom-style if-map-get($chapter-number-border-bottom-color, $type);
+      border-bottom: if-map-get($chapter-number-border-bottom-width, $type) $chapter-number-border-bottom-style;
+      border-bottom-color: if-map-get($chapter-number-border-bottom-color, $type); =
       display: $chapter-number-display;
       margin: if-map-get($chapter-number-margin-top, $type) if-map-get($chapter-number-margin-right, $type) if-map-get($chapter-number-margin-bottom, $type) if-map-get($chapter-number-margin-left, $type);
       padding-bottom: if-map-get($chapter-number-padding-bottom, $type);

--- a/assets/styles/components/section-titles/_chapters.scss
+++ b/assets/styles/components/section-titles/_chapters.scss
@@ -45,7 +45,7 @@
 
     .chapter-number {
       border-bottom: if-map-get($chapter-number-border-bottom-width, $type) $chapter-number-border-bottom-style;
-      border-bottom-color: if-map-get($chapter-number-border-bottom-color, $type); =
+      border-bottom-color: if-map-get($chapter-number-border-bottom-color, $type);
       display: $chapter-number-display;
       margin: if-map-get($chapter-number-margin-top, $type) if-map-get($chapter-number-margin-right, $type) if-map-get($chapter-number-margin-bottom, $type) if-map-get($chapter-number-margin-left, $type);
       padding-bottom: if-map-get($chapter-number-padding-bottom, $type);

--- a/assets/styles/components/section-titles/_front-matter.scss
+++ b/assets/styles/components/section-titles/_front-matter.scss
@@ -21,7 +21,8 @@
       font-size: if-map-get($front-matter-title-font-size, $type);
       font-style: $front-matter-title-font-style;
       font-weight: $front-matter-title-font-weight;
-      border-bottom: $front-matter-title-border-bottom-style if-map-get($front-matter-title-border-bottom-width, $type) if-map-get($front-matter-title-border-bottom-color, $type);
+      border-bottom: $front-matter-title-border-bottom-style if-map-get($front-matter-title-border-bottom-width, $type);
+      border-bottom-color: if-map-get($front-matter-title-border-bottom-color, $type);
       letter-spacing: if-map-get($front-matter-title-letter-spacing, $type);
       word-spacing: if-map-get($front-matter-title-word-spacing, $type);
       hyphens: none;
@@ -109,7 +110,8 @@
   #toc h1 {
     display: block;
     margin: if-map-get($toc-title-margin-top, $type) if-map-get($toc-title-margin-right, $type) if-map-get($toc-title-margin-bottom, $type) if-map-get($toc-title-margin-left, $type);
-    border-bottom: $toc-title-border-bottom-style if-map-get($toc-title-border-bottom-width, $type) if-map-get($toc-title-border-bottom-color, $type);
+    border-bottom: $toc-title-border-bottom-style if-map-get($toc-title-border-bottom-width, $type);
+    border-bottom-color: if-map-get($toc-title-border-bottom-color, $type);
     padding-bottom: if-map-get($toc-title-padding-bottom, $type);
     font-family: $toc-title-font-family;
     font-size: if-map-get($toc-title-font-size, $type);

--- a/assets/styles/components/section-titles/_generic.scss
+++ b/assets/styles/components/section-titles/_generic.scss
@@ -29,7 +29,8 @@
         text-transform: $part-title-text-transform;
 
         span {
-          border-bottom: $part-number-border-bottom-style if-map-get($part-number-border-bottom-width, $type) if-map-get($part-number-border-bottom-color, $type);
+          border-bottom: $part-number-border-bottom-style if-map-get($part-number-border-bottom-width, $type);
+          border-bottom-color: if-map-get($part-number-border-bottom-color, $type);
           display: $part-number-display;
           margin: if-map-get($part-number-margin-top, $type) if-map-get($part-number-margin-right, $type) if-map-get($part-number-margin-bottom, $type) if-map-get($part-number-margin-left, $type);
           padding-bottom: if-map-get($part-number-padding-bottom, $type);
@@ -125,7 +126,8 @@
         text-transform: $chapter-title-text-transform;
 
         span {
-          border-bottom: $chapter-number-border-bottom-style if-map-get($chapter-number-border-bottom-width, $type) if-map-get($chapter-number-border-bottom-color, $type);
+          border-bottom: $chapter-number-border-bottom-style if-map-get($chapter-number-border-bottom-width, $type);
+          border-bottom-color: if-map-get($chapter-number-border-bottom-color, $type);
           display: $chapter-number-display;
           margin: if-map-get($chapter-number-margin-top, $type) if-map-get($chapter-number-margin-right, $type) if-map-get($chapter-number-margin-bottom, $type) if-map-get($chapter-number-margin-left, $type);
           padding-bottom: if-map-get($chapter-number-padding-bottom, $type);

--- a/assets/styles/components/section-titles/_parts.scss
+++ b/assets/styles/components/section-titles/_parts.scss
@@ -11,7 +11,8 @@
     margin: if-map-get($section-header-margin-top, $type) if-map-get($section-header-margin-right, $type) if-map-get($section-header-margin-bottom, $type) if-map-get($section-header-margin-left, $type);
 
     .part-number {
-      border-bottom: $part-number-border-bottom-style if-map-get($part-number-border-bottom-width, $type) if-map-get($part-number-border-bottom-color, $type);
+      border-bottom: $part-number-border-bottom-style if-map-get($part-number-border-bottom-width, $type);
+      border-bottom-color: if-map-get($part-number-border-bottom-color, $type);
       display: $part-number-display;
       margin: if-map-get($part-number-margin-top, $type) if-map-get($part-number-margin-right, $type) if-map-get($part-number-margin-bottom, $type) if-map-get($part-number-margin-left, $type);
       padding-bottom: if-map-get($part-number-padding-bottom, $type);
@@ -51,7 +52,8 @@
       page-break-after: avoid;
       letter-spacing: if-map-get($part-title-letter-spacing, $type);
       word-spacing: if-map-get($part-title-word-spacing, $type);
-      border-bottom: if-map-get($part-title-border-bottom-width, $type) $part-title-border-bottom-style if-map-get($part-title-border-bottom-color, $type);
+      border-bottom: if-map-get($part-title-border-bottom-width, $type) $part-title-border-bottom-style;
+      border-bottom-color: if-map-get($part-title-border-bottom-color, $type);
 
       @if  $part-title-decoration-content != "" or $part-title-decoration-display != none {
         &::after {

--- a/assets/styles/components/specials/_pullquotes.scss
+++ b/assets/styles/components/specials/_pullquotes.scss
@@ -38,8 +38,10 @@ aside,
 
   text-align: $pullquote-align;
   text-indent: 0;
-  border-top: if-map-get($pullquote-border-top-width, $type) $pullquote-border-top-style $pullquote-border-top-color;
-  border-bottom: if-map-get($pullquote-border-bottom-width, $type) $pullquote-border-bottom-style $pullquote-border-bottom-color;
+  border-top: if-map-get($pullquote-border-top-width, $type) $pullquote-border-top-style;
+  border-top-color: $pullquote-border-top-color;
+  border-bottom: if-map-get($pullquote-border-bottom-width, $type) $pullquote-border-bottom-style;
+  border-bottom-color: $pullquote-border-bottom-color;
   padding-top: if-map-get($pullquote-padding-top, $type);
   padding-bottom: if-map-get($pullquote-padding-bottom, $type);
   page-break-inside: avoid;

--- a/assets/styles/components/specials/_separators.scss
+++ b/assets/styles/components/specials/_separators.scss
@@ -28,13 +28,15 @@ hr {
   margin: if-map-get($hr-margin-top, $type) auto $hr-margin-bottom;
   border-top: none;
   border-right: none;
-  border-bottom: $hr-border-style $hr-border-width $hr-border-color;
+  border-bottom: $hr-border-style $hr-border-width;
+  border-bottom-color: $hr-border-color;
   border-left: none;
   text-align: center;
 
   &.break-symbols {
     padding-top: if-map-get($hr-break-symbols-padding-top, $type);
-    border-top: if-map-get($hr-break-symbols-border-top-width, $type) if-map-get($hr-break-symbols-border-top-style, $type) if-map-get($hr-break-symbols-border-top-color, $type);
+    border-top: if-map-get($hr-break-symbols-border-top-width, $type) if-map-get($hr-break-symbols-border-top-style, $type);
+    border-top-color: if-map-get($hr-break-symbols-border-top-color, $type);
     margin-top: if-map-get($hr-break-symbols-margin-top, $type);
     margin-bottom: $hr-break-symbols-margin-bottom;
     border: 0;

--- a/assets/styles/components/specials/_separators.scss
+++ b/assets/styles/components/specials/_separators.scss
@@ -35,11 +35,11 @@ hr {
 
   &.break-symbols {
     padding-top: if-map-get($hr-break-symbols-padding-top, $type);
+    border: 0;
     border-top: if-map-get($hr-break-symbols-border-top-width, $type) if-map-get($hr-break-symbols-border-top-style, $type);
     border-top-color: if-map-get($hr-break-symbols-border-top-color, $type);
     margin-top: if-map-get($hr-break-symbols-margin-top, $type);
     margin-bottom: $hr-break-symbols-margin-bottom;
-    border: 0;
 
     &::after {
       display: block;


### PR DESCRIPTION
You can't use the `initial` color keyword in a border shorthand rule:

```css
/* This doesn't work. */
border: 1px solid initial;

/* This works. */
border: 1px solid;
border-color: initial;
```

This issue was identified when table styling was implemented but the same approach wasn't used on section title bottom borders for some reason. This PR resolves #328.