### PR TITLE
fix: set tag types for TOC properly in PDF exports

### DIFF
--- a/assets/styles/components/toc/_center.scss
+++ b/assets/styles/components/toc/_center.scss
@@ -36,6 +36,14 @@
 
 @if $type == 'prince' {
   #toc {
+    ul {
+      -prince-pdf-tag-type: TOC;
+    }
+
+    li {
+      -prince-pdf-tag-type: TOCI;
+    }
+
     a::after {
       display: $toc-center-page-number-display;
     }

--- a/assets/styles/components/toc/_center.scss
+++ b/assets/styles/components/toc/_center.scss
@@ -37,10 +37,12 @@
 @if $type == 'prince' {
   #toc {
     ul {
+      /* stylelint-disable-next-line value-keyword-case */
       -prince-pdf-tag-type: TOC;
     }
 
     li {
+      /* stylelint-disable-next-line value-keyword-case */
       -prince-pdf-tag-type: TOCI;
     }
 

--- a/assets/styles/components/toc/_generic.scss
+++ b/assets/styles/components/toc/_generic.scss
@@ -252,10 +252,12 @@
     }
 
     ul {
+      -prince-pdf-tag-type: TOC;
       counter-reset: chapter;
     }
 
     li {
+      -prince-pdf-tag-type: TOCI;
       page-break-inside: avoid;
       position: relative;
     }

--- a/assets/styles/components/toc/_generic.scss
+++ b/assets/styles/components/toc/_generic.scss
@@ -252,11 +252,13 @@
     }
 
     ul {
+      /* stylelint-disable-next-line value-keyword-case */
       -prince-pdf-tag-type: TOC;
       counter-reset: chapter;
     }
 
     li {
+      /* stylelint-disable-next-line value-keyword-case */
       -prince-pdf-tag-type: TOCI;
       page-break-inside: avoid;
       position: relative;

--- a/assets/styles/components/toc/_left.scss
+++ b/assets/styles/components/toc/_left.scss
@@ -52,6 +52,14 @@
 
 @if $type == 'prince' {
   #toc {
+    ul {
+      -prince-pdf-tag-type: TOC;
+    }
+
+    li {
+      -prince-pdf-tag-type: TOCI;
+    }
+
     a::after {
       display: $toc-left-page-number-display;
       position: absolute;

--- a/assets/styles/components/toc/_left.scss
+++ b/assets/styles/components/toc/_left.scss
@@ -53,10 +53,12 @@
 @if $type == 'prince' {
   #toc {
     ul {
+      /* stylelint-disable-next-line value-keyword-case */
       -prince-pdf-tag-type: TOC;
     }
 
     li {
+      /* stylelint-disable-next-line value-keyword-case */
       -prince-pdf-tag-type: TOCI;
     }
 


### PR DESCRIPTION
See pressbooks/private#2099.

To test:

1. Copy these files into `pressbooks-book/packages/buckram`.
2. Export a PDF.
3. Inspect tags in Acrobat Pro.