### PR TITLE
feat: prince 16 support

### DIFF
--- a/assets/styles/components/elements/_blockquotes.scss
+++ b/assets/styles/components/elements/_blockquotes.scss
@@ -19,6 +19,7 @@
     word-spacing: if-map-get($blockquote-word-spacing, $type);
     border-left: if-map-get($blockquote-border-left-width, $type) $blockquote-border-left-style;
     border-left-color: $blockquote-border-left-color;
+    box-decoration-break: $box-decoration-break;
     @if $type == 'prince' {
       line-height: $blockquote-line-height;
     }

--- a/assets/styles/components/specials/_footnotes.scss
+++ b/assets/styles/components/specials/_footnotes.scss
@@ -134,6 +134,7 @@
   ol {
     margin-top: $endnote-ol-margin-top;
     margin-left: $endnote-ol-margin-left;
+    padding-left: $endnote-ol-padding-left;
     font-size: $endnote-ol-font-size;
     list-style-position: outside;
   }

--- a/assets/styles/components/specials/_pullquotes.scss
+++ b/assets/styles/components/specials/_pullquotes.scss
@@ -21,6 +21,7 @@ aside,
   border-right: $aside-border-right;
   border-bottom: $aside-border-bottom;
   border-left: $aside-border-left;
+  box-decoration-break: $box-decoration-break;
 }
 
 // Pullquotes

--- a/assets/styles/components/specials/_textboxes.scss
+++ b/assets/styles/components/specials/_textboxes.scss
@@ -113,15 +113,18 @@
   border-style: $textbox-border-style;
   border-width: if-map-get($textbox-border-width, $type);
   border-radius: if-map-get($textbox-border-radius, $type);
+  box-decoration-break: $box-decoration-break;
 
   ul {
     margin-top: $textbox-ul-margin-top;
     margin-bottom: $textbox-ul-margin-bottom;
+    padding-left: $textbox-ul-padding-left;
   }
 
   ol {
     margin-top: $textbox-ol-margin-top;
     margin-bottom: $textbox-ol-margin-bottom;
+    padding-left: $textbox-ol-padding-left;
   }
 
   li {

--- a/assets/styles/components/structure/_mixins.scss
+++ b/assets/styles/components/structure/_mixins.scss
@@ -14,7 +14,7 @@
     @each $page-type in
       'front-matter:#{$page-position}' {
       @page #{$page-type} {
-        @if $page-position == 'first:left' {
+        @if $page-position == 'first-of-group:left' {
           @if if-map-get($content-position, left) {
             @include position(if-map-get($content-position, left)) {
               @if head-or-foot(if-map-get($content-position, left)) == 'head' {
@@ -26,7 +26,7 @@
               @include front-matter-page-number;
             }
           }
-        } @else if $page-position == 'first:right' {
+        } @else if $page-position == 'first-of-group:right' {
           @if if-map-get($content-position, right) {
             @include position(if-map-get($content-position, right)) {
               @if head-or-foot(if-map-get($content-position, right)) == 'head' {
@@ -59,7 +59,7 @@
       'chapter:#{$page-position}',
       'back-matter:#{$page-position}' {
       @page #{$page-type} {
-        @if $page-position == 'first:left' {
+        @if $page-position == 'first-of-group:left' {
           @if if-map-get($content-position, left) {
             @include position(if-map-get($content-position, left)) {
               @if head-or-foot(if-map-get($content-position, left)) == 'head' {
@@ -71,7 +71,7 @@
               @include page-number;
             }
           }
-        } @else if $page-position == 'first:right' {
+        } @else if $page-position == 'first-of-group:right' {
           @if if-map-get($content-position, right) {
             @include position(if-map-get($content-position, right)) {
               @if head-or-foot(if-map-get($content-position, right)) == 'head' {
@@ -217,7 +217,7 @@
     'chapter:#{$page-position}',
     'back-matter:#{$page-position}' {
     @page #{$page-type} {
-      @if $page-position == 'first:left' {
+      @if $page-position == 'first-of-group:left' {
         @if if-map-get($content-position, left) {
           @include position(if-map-get($content-position, left)) {
             padding-top: $runninghead-padding-top;
@@ -232,7 +232,7 @@
             text-transform: $runninghead-left-text-transform;
           }
         }
-      } @else if $page-position == 'first:right' {
+      } @else if $page-position == 'first-of-group:right' {
         @if if-map-get($content-position, right) {
           @include position(if-map-get($content-position, right)) {
             padding-top: $runninghead-padding-top;
@@ -290,7 +290,7 @@
     'chapter:#{$page-position}',
     'back-matter:#{$page-position}' {
     @page #{$page-type} {
-      @if $page-position == 'first:left' {
+      @if $page-position == 'first-of-group:left' {
         @if if-map-get($content-position, left) {
           @include position(if-map-get($content-position, left)) {
             padding-bottom: $runningfoot-padding-bottom;
@@ -305,7 +305,7 @@
             text-transform: $runningfoot-left-text-transform;
           }
         }
-      } @else if $page-position == 'first:right' {
+      } @else if $page-position == 'first-of-group:right' {
         @if if-map-get($content-position, right) {
           @include position(if-map-get($content-position, right)) {
             padding-bottom: $runningfoot-padding-bottom;
@@ -359,7 +359,7 @@
 @mixin page-structure($page-type, $page-position, $numbering-position, $running-content-position) {
   @if $numbering-position and $running-content-position {
     @if $numbering-position == $running-content-position {
-      @if $page-position != 'first' {
+      @if $page-position != 'first-of-group' {
         @page #{$page-type}:#{$page-position} {
           @include position($running-content-position) {
             @if $page-position == 'left' {
@@ -384,7 +384,7 @@
           }
         }
       } @else {
-        @page #{$page-type}:first:right {
+        @page #{$page-type}:first-of-group:right {
           @include position(if-map-get($running-content-position, right)) {
             @if if-map-get($running-content-position, right) == '@bottom-left'
               or if-map-get($running-content-position, right) == '@bottom-left-corner'
@@ -396,7 +396,7 @@
           }
         }
 
-        @page #{$page-type}:first:left {
+        @page #{$page-type}:first-of-group:left {
           @include position(if-map-get($running-content-position, left)) {
             @if if-map-get($running-content-position, left) == '@bottom-right'
               or if-map-get($running-content-position, left) == '@bottom-right-corner'
@@ -409,7 +409,7 @@
         }
       }
     } @else {
-      @if $page-position != 'first' {
+      @if $page-position != 'first-of-group' {
         @page #{$page-type}:#{$page-position} {
           @include position($running-content-position) {
             @if $page-position == 'left' {
@@ -429,7 +429,7 @@
 
         }
       } @else {
-        @page #{$page-type}:first:right {
+        @page #{$page-type}:first-of-group:right {
           @include position(if-map-get($running-content-position, right)) {
             content: if-map-get($right-running-content, $page-type);
           }
@@ -438,7 +438,7 @@
           }
         }
 
-        @page #{$page-type}:first:left {
+        @page #{$page-type}:first-of-group:left {
           @include position(if-map-get($running-content-position, left)) {
             content: if-map-get($left-running-content, $page-type);
           }
@@ -450,7 +450,7 @@
     }
   } @else {
     @if $numbering-position {
-      @if $page-position != 'first' {
+      @if $page-position != 'first-of-group' {
         @page #{$page-type}:#{$page-position} {
           @include position($numbering-position) {
             @if $page-position == 'left' {
@@ -461,13 +461,13 @@
           }
         }
       } @else {
-        @page #{$page-type}:first:right {
+        @page #{$page-type}:first-of-group:right {
           @include position(if-map-get($numbering-position, right)) {
             content: if-map-get($right-page-number, $page-type);
           }
         }
 
-        @page #{$page-type}:first:left {
+        @page #{$page-type}:first-of-group:left {
           @include position(if-map-get($numbering-position, left)) {
             content: if-map-get($left-page-number, $page-type);
           }
@@ -476,7 +476,7 @@
     }
 
     @if $running-content-position {
-      @if $page-position != 'first' {
+      @if $page-position != 'first-of-group' {
         @page #{$page-type}:#{$page-position} {
           @include position($running-content-position) {
             @if $page-position == 'left' {
@@ -487,13 +487,13 @@
           }
         }
       } @else {
-        @page #{$page-type}:first:right {
+        @page #{$page-type}:first-of-group:right {
           @include position(if-map-get($running-content-position, right)) {
             content: if-map-get($right-running-content, $page-type);
           }
         }
 
-        @page #{$page-type}:first:left {
+        @page #{$page-type}:first-of-group:left {
           @include position(if-map-get($running-content-position, left)) {
             content: if-map-get($left-running-content, $page-type);
           }

--- a/assets/styles/components/structure/_running-content.scss
+++ b/assets/styles/components/structure/_running-content.scss
@@ -51,8 +51,8 @@ $right-page-number: (
 
 // Now we style the appropriate location using our page-numbers mixin.
 
-@include page-numbers('first:left', convert-position('first', $first-numbering-position));
-@include page-numbers('first:right', convert-position('first', $first-numbering-position));
+@include page-numbers('first-of-group:left', convert-position('first', $first-numbering-position));
+@include page-numbers('first-of-group:right', convert-position('first', $first-numbering-position));
 @include page-numbers('left', convert-position('left', $numbering-position));
 @include page-numbers('right', convert-position('right', $numbering-position));
 
@@ -62,13 +62,13 @@ $right-page-number: (
 // Now we style the appropriate location using our runninghead or runningfoot mixin.
 
 @if head-or-foot($running-content-position) == 'head' {
-  @include runninghead('first:left', convert-position('first', $first-running-content-position));
-  @include runninghead('first:right', convert-position('first', $first-running-content-position));
+  @include runninghead('first-of-group:left', convert-position('first', $first-running-content-position));
+  @include runninghead('first-of-group:right', convert-position('first', $first-running-content-position));
   @include runninghead('left', convert-position('left', $running-content-position));
   @include runninghead('right', convert-position('right', $running-content-position));
 } @else if head-or-foot($running-content-position) == 'foot' {
-  @include runningfoot('first:left', convert-position('first', $first-running-content-position));
-  @include runningfoot('first:right', convert-position('first', $first-running-content-position));
+  @include runningfoot('first-of-group:left', convert-position('first', $first-running-content-position));
+  @include runningfoot('first-of-group:right', convert-position('first', $first-running-content-position));
   @include runningfoot('left', convert-position('left', $running-content-position));
   @include runningfoot('right', convert-position('right', $running-content-position));
 }
@@ -80,56 +80,56 @@ $right-page-number: (
 // depending on section type
 
 // Front Matter
-@page front-matter:first {
+@page front-matter:first-of-group {
   @include blank-head-and-foot;
 }
 
-@include page-structure('front-matter', 'first', convert-position('first', $first-numbering-position), convert-position('first', $first-running-content-position));
+@include page-structure('front-matter', 'first-of-group', convert-position('first', $first-numbering-position), convert-position('first', $first-running-content-position));
 @include page-structure('front-matter', 'left', convert-position('left', $numbering-position), convert-position('left', $running-content-position));
 @include page-structure('front-matter', 'right', convert-position('right', $numbering-position), convert-position('right', $running-content-position));
 
 // Introduction
-@page introduction:first {
+@page introduction:first-of-group {
   @include blank-head-and-foot;
 }
 
-@include page-structure('introduction', 'first', convert-position('first', $first-numbering-position), convert-position('first', $first-running-content-position));
+@include page-structure('introduction', 'first-of-group', convert-position('first', $first-numbering-position), convert-position('first', $first-running-content-position));
 @include page-structure('introduction', 'left', convert-position('left', $numbering-position), convert-position('left', $running-content-position));
 @include page-structure('introduction', 'right', convert-position('right', $numbering-position), convert-position('right', $running-content-position));
 
 // Post-introduction
-@page post-introduction:first {
+@page post-introduction:first-of-group {
   @include blank-head-and-foot;
 }
 
-@include page-structure('post-introduction', 'first', convert-position('first', $first-numbering-position), convert-position('first', $first-running-content-position));
+@include page-structure('post-introduction', 'first-of-group', convert-position('first', $first-numbering-position), convert-position('first', $first-running-content-position));
 @include page-structure('post-introduction', 'left', convert-position('left', $numbering-position), convert-position('left', $running-content-position));
 @include page-structure('post-introduction', 'right', convert-position('right', $numbering-position), convert-position('right', $running-content-position));
 
 
 // Parts
-@page part:first {
+@page part:first-of-group {
   @include blank-head-and-foot;
 }
 
-@include page-structure('part', 'first', convert-position('first', $first-numbering-position), convert-position('first', $first-running-content-position));
+@include page-structure('part', 'first-of-group', convert-position('first', $first-numbering-position), convert-position('first', $first-running-content-position));
 @include page-structure('part', 'left', convert-position('left', $numbering-position), convert-position('left', $running-content-position));
 @include page-structure('part', 'right', convert-position('right', $numbering-position), convert-position('right', $running-content-position));
 
 // Chapters
-@page chapter:first {
+@page chapter:first-of-group {
   @include blank-head-and-foot;
 }
 
-@include page-structure('chapter', 'first', convert-position('first', $first-numbering-position), convert-position('first', $first-running-content-position));
+@include page-structure('chapter', 'first-of-group', convert-position('first', $first-numbering-position), convert-position('first', $first-running-content-position));
 @include page-structure('chapter', 'left', convert-position('left', $numbering-position), convert-position('left', $running-content-position));
 @include page-structure('chapter', 'right', convert-position('right', $numbering-position), convert-position('right', $running-content-position));
 
 // Back Matter
-@page back-matter:first {
+@page back-matter:first-of-group {
   @include blank-head-and-foot;
 }
 
-@include page-structure('back-matter', 'first', convert-position('first', $first-numbering-position), convert-position('first', $first-running-content-position));
+@include page-structure('back-matter', 'first-of-group', convert-position('first', $first-numbering-position), convert-position('first', $first-running-content-position));
 @include page-structure('back-matter', 'left', convert-position('left', $numbering-position), convert-position('left', $running-content-position));
 @include page-structure('back-matter', 'right', convert-position('right', $numbering-position), convert-position('right', $running-content-position));

--- a/assets/styles/variables/_elements.scss
+++ b/assets/styles/variables/_elements.scss
@@ -755,6 +755,13 @@ $blockquote-border-left-style: none !default;
 /// @since 1.0.0
 $blockquote-border-left-color: initial !default;
 
+/// Box decoration break behavior for elements that may span page breaks (textboxes, asides, blockquotes).
+/// Set to `clone` to restore Prince 15 behavior where borders, padding, and backgrounds
+/// are repeated on each page fragment. Prince 16+ defaults to `slice` per CSS spec.
+/// @type String
+/// @since 1.9.0
+$box-decoration-break: clone !default;
+
 /// Top margin for `<ol>` elements.
 /// @type String | Map
 $ol-margin-top: 1em !default;

--- a/assets/styles/variables/_specials.scss
+++ b/assets/styles/variables/_specials.scss
@@ -204,6 +204,12 @@ $endnote-ol-margin-top: 0.4em !default;
 /// @type String
 $endnote-ol-margin-left: 0 !default;
 
+/// Left padding on ordered lists within endnotes on `<ol>` elements that are children of elements with a class of `endnotes`.
+/// Required for correct list indentation in Prince 16+ which uses padding-based list indentation.
+/// @type String
+/// @since 1.9.0
+$endnote-ol-padding-left: 0 !default;
+
 /// Font size on ordered lists within endnotes on `<ol>` elements that are children of elements with a class of `endnotes`.
 /// @type String
 $endnote-ol-font-size: 0.85em !default;
@@ -690,6 +696,12 @@ $textbox-ol-margin-top: 1em !default;
 /// @since 1.0.0
 $textbox-ol-margin-bottom: 0.75em !default;
 
+/// Textbox left padding on `<ol>` elements that are children of elements with a class of `textbox`.
+/// Required for correct list indentation in Prince 16+ which uses padding-based list indentation.
+/// @type String
+/// @since 1.9.0
+$textbox-ol-padding-left: 1em !default;
+
 /// Textbox header top margin on `<ul>` elements that are children of elements with a class of `textbox`.
 /// @type String
 /// @since 1.0.0
@@ -699,6 +711,12 @@ $textbox-ul-margin-top: 1em !default;
 /// @type String
 /// @since 1.0.0
 $textbox-ul-margin-bottom: 0.75em !default;
+
+/// Textbox left padding on `<ul>` elements that are children of elements with a class of `textbox`.
+/// Required for correct list indentation in Prince 16+ which uses padding-based list indentation.
+/// @type String
+/// @since 1.9.0
+$textbox-ul-padding-left: 1em !default;
 
 /// Textbox header left margin on `<li>` elements that are children of elements with a class of `textbox`.
 /// @type String

--- a/package.json
+++ b/package.json
@@ -41,7 +41,10 @@
     "rules": {
       "no-descending-specificity": null,
       "no-duplicate-at-import-rules": null,
-      "scss/no-global-function-names": null
+      "scss/no-global-function-names": null,
+      "selector-pseudo-class-no-unknown": [true, {
+        "ignorePseudoClasses": ["first-of-group"]
+      }]
     }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/pressbooks/pressbooks/issues/4418

This pull request updates the styling for various print and page elements, focusing on two main themes: improving support for multi-page elements by controlling border and background rendering, and refining how page positions are referenced throughout the codebase for consistency with newer CSS/PrinceXML 16 standards.

**Key changes:**

**1. Improved multi-page element rendering:**
- Introduced the `$box-decoration-break` variable (defaulting to `clone`) to control the rendering of borders, padding, and backgrounds for elements like blockquotes, asides, and textboxes that span across page breaks. This restores the Prince 15 behavior for these elements, ensuring visual consistency when content flows over multiple pages.
- Applied `box-decoration-break: $box-decoration-break;` to blockquotes, asides, and textboxes for consistent border/background rendering across page breaks. [[1]](diffhunk://#diff-c66223e25c8aa598d77ef7397e927a1f3e34951544d936430c12a76ecbe30e4cR22) [[2]](diffhunk://#diff-671353e2ed36777800169b72d98eebea11b0e3c0ce20a64795ee42303afe303fR24) [[3]](diffhunk://#diff-c96e6978b5e45fae3d6bfe2f376000604826ab0d571daa2550b35b64da8d5891R116-R127)

**2. Consistent page position references for print layout:**
- Updated all references of `first:left` and `first:right` to `first-of-group:left` and `first-of-group:right` in mixins and includes, aligning with PrinceXML 16+ and the CSS Paged Media spec. This affects page numbering, running heads/feet, and blank page styling for all major page types (front matter, chapters, parts, etc.). [[1]](diffhunk://#diff-75ba094f486efd0257613dd9bc81d7a4f0795ea13b8b4181ac625673b0c316bbL17-R17) [[2]](diffhunk://#diff-75ba094f486efd0257613dd9bc81d7a4f0795ea13b8b4181ac625673b0c316bbL29-R29) [[3]](diffhunk://#diff-75ba094f486efd0257613dd9bc81d7a4f0795ea13b8b4181ac625673b0c316bbL62-R62) [[4]](diffhunk://#diff-75ba094f486efd0257613dd9bc81d7a4f0795ea13b8b4181ac625673b0c316bbL74-R74) [[5]](diffhunk://#diff-75ba094f486efd0257613dd9bc81d7a4f0795ea13b8b4181ac625673b0c316bbL220-R220) [[6]](diffhunk://#diff-75ba094f486efd0257613dd9bc81d7a4f0795ea13b8b4181ac625673b0c316bbL235-R235) [[7]](diffhunk://#diff-75ba094f486efd0257613dd9bc81d7a4f0795ea13b8b4181ac625673b0c316bbL293-R293) [[8]](diffhunk://#diff-75ba094f486efd0257613dd9bc81d7a4f0795ea13b8b4181ac625673b0c316bbL308-R308) [[9]](diffhunk://#diff-75ba094f486efd0257613dd9bc81d7a4f0795ea13b8b4181ac625673b0c316bbL362-R362) [[10]](diffhunk://#diff-75ba094f486efd0257613dd9bc81d7a4f0795ea13b8b4181ac625673b0c316bbL387-R387) [[11]](diffhunk://#diff-75ba094f486efd0257613dd9bc81d7a4f0795ea13b8b4181ac625673b0c316bbL399-R399) [[12]](diffhunk://#diff-75ba094f486efd0257613dd9bc81d7a4f0795ea13b8b4181ac625673b0c316bbL412-R412) [[13]](diffhunk://#diff-75ba094f486efd0257613dd9bc81d7a4f0795ea13b8b4181ac625673b0c316bbL432-R432) [[14]](diffhunk://#diff-75ba094f486efd0257613dd9bc81d7a4f0795ea13b8b4181ac625673b0c316bbL441-R441) [[15]](diffhunk://#diff-75ba094f486efd0257613dd9bc81d7a4f0795ea13b8b4181ac625673b0c316bbL453-R453) [[16]](diffhunk://#diff-75ba094f486efd0257613dd9bc81d7a4f0795ea13b8b4181ac625673b0c316bbL464-R470) [[17]](diffhunk://#diff-75ba094f486efd0257613dd9bc81d7a4f0795ea13b8b4181ac625673b0c316bbL479-R479) [[18]](diffhunk://#diff-75ba094f486efd0257613dd9bc81d7a4f0795ea13b8b4181ac625673b0c316bbL490-R496) [[19]](diffhunk://#diff-18a08da01360d97b3534db67d9015dcf5c85774bc39c792ea2b9896f3ea4a98bL54-R55) [[20]](diffhunk://#diff-18a08da01360d97b3534db67d9015dcf5c85774bc39c792ea2b9896f3ea4a98bL65-R71) [[21]](diffhunk://#diff-18a08da01360d97b3534db67d9015dcf5c85774bc39c792ea2b9896f3ea4a98bL83-R133)

**3. Minor layout improvements:**
- Added `padding-left` to ordered and unordered lists in footnotes and textboxes for improved alignment and readability. [[1]](diffhunk://#diff-26071b8279755af9bdd529776cc3fc3a27b59595f35e1cceeba3a0596b24b48bR137) [[2]](diffhunk://#diff-c96e6978b5e45fae3d6bfe2f376000604826ab0d571daa2550b35b64da8d5891R116-R127)

These changes collectively modernize the print layout system and improve the appearance of multi-page elements in generated documents.