### PR TITLE
feat: new dynamic parameters

### DIFF
--- a/assets/styles/components/structure/_mixins.scss
+++ b/assets/styles/components/structure/_mixins.scss
@@ -14,7 +14,7 @@
     @each $page-type in
       'front-matter:#{$page-position}' {
       @page #{$page-type} {
-        @if $page-position == 'first-of-group:left' {
+        @if $page-position == '#{$first-page-pseudo}:left' {
           @if if-map-get($content-position, left) {
             @include position(if-map-get($content-position, left)) {
               @if head-or-foot(if-map-get($content-position, left)) == 'head' {
@@ -26,7 +26,7 @@
               @include front-matter-page-number;
             }
           }
-        } @else if $page-position == 'first-of-group:right' {
+        } @else if $page-position == '#{$first-page-pseudo}:right' {
           @if if-map-get($content-position, right) {
             @include position(if-map-get($content-position, right)) {
               @if head-or-foot(if-map-get($content-position, right)) == 'head' {
@@ -59,7 +59,7 @@
       'chapter:#{$page-position}',
       'back-matter:#{$page-position}' {
       @page #{$page-type} {
-        @if $page-position == 'first-of-group:left' {
+        @if $page-position == '#{$first-page-pseudo}:left' {
           @if if-map-get($content-position, left) {
             @include position(if-map-get($content-position, left)) {
               @if head-or-foot(if-map-get($content-position, left)) == 'head' {
@@ -71,7 +71,7 @@
               @include page-number;
             }
           }
-        } @else if $page-position == 'first-of-group:right' {
+        } @else if $page-position == '#{$first-page-pseudo}:right' {
           @if if-map-get($content-position, right) {
             @include position(if-map-get($content-position, right)) {
               @if head-or-foot(if-map-get($content-position, right)) == 'head' {
@@ -217,7 +217,7 @@
     'chapter:#{$page-position}',
     'back-matter:#{$page-position}' {
     @page #{$page-type} {
-      @if $page-position == 'first-of-group:left' {
+      @if $page-position == '#{$first-page-pseudo}:left' {
         @if if-map-get($content-position, left) {
           @include position(if-map-get($content-position, left)) {
             padding-top: $runninghead-padding-top;
@@ -232,7 +232,7 @@
             text-transform: $runninghead-left-text-transform;
           }
         }
-      } @else if $page-position == 'first-of-group:right' {
+      } @else if $page-position == '#{$first-page-pseudo}:right' {
         @if if-map-get($content-position, right) {
           @include position(if-map-get($content-position, right)) {
             padding-top: $runninghead-padding-top;
@@ -290,7 +290,7 @@
     'chapter:#{$page-position}',
     'back-matter:#{$page-position}' {
     @page #{$page-type} {
-      @if $page-position == 'first-of-group:left' {
+      @if $page-position == '#{$first-page-pseudo}:left' {
         @if if-map-get($content-position, left) {
           @include position(if-map-get($content-position, left)) {
             padding-bottom: $runningfoot-padding-bottom;
@@ -305,7 +305,7 @@
             text-transform: $runningfoot-left-text-transform;
           }
         }
-      } @else if $page-position == 'first-of-group:right' {
+      } @else if $page-position == '#{$first-page-pseudo}:right' {
         @if if-map-get($content-position, right) {
           @include position(if-map-get($content-position, right)) {
             padding-bottom: $runningfoot-padding-bottom;
@@ -359,7 +359,7 @@
 @mixin page-structure($page-type, $page-position, $numbering-position, $running-content-position) {
   @if $numbering-position and $running-content-position {
     @if $numbering-position == $running-content-position {
-      @if $page-position != 'first-of-group' {
+      @if $page-position != $first-page-pseudo {
         @page #{$page-type}:#{$page-position} {
           @include position($running-content-position) {
             @if $page-position == 'left' {
@@ -384,7 +384,7 @@
           }
         }
       } @else {
-        @page #{$page-type}:first-of-group:right {
+        @page #{$page-type}:#{$first-page-pseudo}:right {
           @include position(if-map-get($running-content-position, right)) {
             @if if-map-get($running-content-position, right) == '@bottom-left'
               or if-map-get($running-content-position, right) == '@bottom-left-corner'
@@ -396,7 +396,7 @@
           }
         }
 
-        @page #{$page-type}:first-of-group:left {
+        @page #{$page-type}:#{$first-page-pseudo}:left {
           @include position(if-map-get($running-content-position, left)) {
             @if if-map-get($running-content-position, left) == '@bottom-right'
               or if-map-get($running-content-position, left) == '@bottom-right-corner'
@@ -409,7 +409,7 @@
         }
       }
     } @else {
-      @if $page-position != 'first-of-group' {
+      @if $page-position != $first-page-pseudo {
         @page #{$page-type}:#{$page-position} {
           @include position($running-content-position) {
             @if $page-position == 'left' {
@@ -429,7 +429,7 @@
 
         }
       } @else {
-        @page #{$page-type}:first-of-group:right {
+        @page #{$page-type}:#{$first-page-pseudo}:right {
           @include position(if-map-get($running-content-position, right)) {
             content: if-map-get($right-running-content, $page-type);
           }
@@ -438,7 +438,7 @@
           }
         }
 
-        @page #{$page-type}:first-of-group:left {
+        @page #{$page-type}:#{$first-page-pseudo}:left {
           @include position(if-map-get($running-content-position, left)) {
             content: if-map-get($left-running-content, $page-type);
           }
@@ -450,7 +450,7 @@
     }
   } @else {
     @if $numbering-position {
-      @if $page-position != 'first-of-group' {
+      @if $page-position != $first-page-pseudo {
         @page #{$page-type}:#{$page-position} {
           @include position($numbering-position) {
             @if $page-position == 'left' {
@@ -461,13 +461,13 @@
           }
         }
       } @else {
-        @page #{$page-type}:first-of-group:right {
+        @page #{$page-type}:#{$first-page-pseudo}:right {
           @include position(if-map-get($numbering-position, right)) {
             content: if-map-get($right-page-number, $page-type);
           }
         }
 
-        @page #{$page-type}:first-of-group:left {
+        @page #{$page-type}:#{$first-page-pseudo}:left {
           @include position(if-map-get($numbering-position, left)) {
             content: if-map-get($left-page-number, $page-type);
           }
@@ -476,7 +476,7 @@
     }
 
     @if $running-content-position {
-      @if $page-position != 'first-of-group' {
+      @if $page-position != $first-page-pseudo {
         @page #{$page-type}:#{$page-position} {
           @include position($running-content-position) {
             @if $page-position == 'left' {
@@ -487,13 +487,13 @@
           }
         }
       } @else {
-        @page #{$page-type}:first-of-group:right {
+        @page #{$page-type}:#{$first-page-pseudo}:right {
           @include position(if-map-get($running-content-position, right)) {
             content: if-map-get($right-running-content, $page-type);
           }
         }
 
-        @page #{$page-type}:first-of-group:left {
+        @page #{$page-type}:#{$first-page-pseudo}:left {
           @include position(if-map-get($running-content-position, left)) {
             content: if-map-get($left-running-content, $page-type);
           }

--- a/assets/styles/components/structure/_running-content.scss
+++ b/assets/styles/components/structure/_running-content.scss
@@ -51,8 +51,8 @@ $right-page-number: (
 
 // Now we style the appropriate location using our page-numbers mixin.
 
-@include page-numbers('first-of-group:left', convert-position('first', $first-numbering-position));
-@include page-numbers('first-of-group:right', convert-position('first', $first-numbering-position));
+@include page-numbers('#{$first-page-pseudo}:left', convert-position('first', $first-numbering-position));
+@include page-numbers('#{$first-page-pseudo}:right', convert-position('first', $first-numbering-position));
 @include page-numbers('left', convert-position('left', $numbering-position));
 @include page-numbers('right', convert-position('right', $numbering-position));
 
@@ -62,13 +62,13 @@ $right-page-number: (
 // Now we style the appropriate location using our runninghead or runningfoot mixin.
 
 @if head-or-foot($running-content-position) == 'head' {
-  @include runninghead('first-of-group:left', convert-position('first', $first-running-content-position));
-  @include runninghead('first-of-group:right', convert-position('first', $first-running-content-position));
+  @include runninghead('#{$first-page-pseudo}:left', convert-position('first', $first-running-content-position));
+  @include runninghead('#{$first-page-pseudo}:right', convert-position('first', $first-running-content-position));
   @include runninghead('left', convert-position('left', $running-content-position));
   @include runninghead('right', convert-position('right', $running-content-position));
 } @else if head-or-foot($running-content-position) == 'foot' {
-  @include runningfoot('first-of-group:left', convert-position('first', $first-running-content-position));
-  @include runningfoot('first-of-group:right', convert-position('first', $first-running-content-position));
+  @include runningfoot('#{$first-page-pseudo}:left', convert-position('first', $first-running-content-position));
+  @include runningfoot('#{$first-page-pseudo}:right', convert-position('first', $first-running-content-position));
   @include runningfoot('left', convert-position('left', $running-content-position));
   @include runningfoot('right', convert-position('right', $running-content-position));
 }
@@ -80,56 +80,56 @@ $right-page-number: (
 // depending on section type
 
 // Front Matter
-@page front-matter:first-of-group {
+@page front-matter:#{$first-page-pseudo} {
   @include blank-head-and-foot;
 }
 
-@include page-structure('front-matter', 'first-of-group', convert-position('first', $first-numbering-position), convert-position('first', $first-running-content-position));
+@include page-structure('front-matter', $first-page-pseudo, convert-position('first', $first-numbering-position), convert-position('first', $first-running-content-position));
 @include page-structure('front-matter', 'left', convert-position('left', $numbering-position), convert-position('left', $running-content-position));
 @include page-structure('front-matter', 'right', convert-position('right', $numbering-position), convert-position('right', $running-content-position));
 
 // Introduction
-@page introduction:first-of-group {
+@page introduction:#{$first-page-pseudo} {
   @include blank-head-and-foot;
 }
 
-@include page-structure('introduction', 'first-of-group', convert-position('first', $first-numbering-position), convert-position('first', $first-running-content-position));
+@include page-structure('introduction', $first-page-pseudo, convert-position('first', $first-numbering-position), convert-position('first', $first-running-content-position));
 @include page-structure('introduction', 'left', convert-position('left', $numbering-position), convert-position('left', $running-content-position));
 @include page-structure('introduction', 'right', convert-position('right', $numbering-position), convert-position('right', $running-content-position));
 
 // Post-introduction
-@page post-introduction:first-of-group {
+@page post-introduction:#{$first-page-pseudo} {
   @include blank-head-and-foot;
 }
 
-@include page-structure('post-introduction', 'first-of-group', convert-position('first', $first-numbering-position), convert-position('first', $first-running-content-position));
+@include page-structure('post-introduction', $first-page-pseudo, convert-position('first', $first-numbering-position), convert-position('first', $first-running-content-position));
 @include page-structure('post-introduction', 'left', convert-position('left', $numbering-position), convert-position('left', $running-content-position));
 @include page-structure('post-introduction', 'right', convert-position('right', $numbering-position), convert-position('right', $running-content-position));
 
 
 // Parts
-@page part:first-of-group {
+@page part:#{$first-page-pseudo} {
   @include blank-head-and-foot;
 }
 
-@include page-structure('part', 'first-of-group', convert-position('first', $first-numbering-position), convert-position('first', $first-running-content-position));
+@include page-structure('part', $first-page-pseudo, convert-position('first', $first-numbering-position), convert-position('first', $first-running-content-position));
 @include page-structure('part', 'left', convert-position('left', $numbering-position), convert-position('left', $running-content-position));
 @include page-structure('part', 'right', convert-position('right', $numbering-position), convert-position('right', $running-content-position));
 
 // Chapters
-@page chapter:first-of-group {
+@page chapter:#{$first-page-pseudo} {
   @include blank-head-and-foot;
 }
 
-@include page-structure('chapter', 'first-of-group', convert-position('first', $first-numbering-position), convert-position('first', $first-running-content-position));
+@include page-structure('chapter', $first-page-pseudo, convert-position('first', $first-numbering-position), convert-position('first', $first-running-content-position));
 @include page-structure('chapter', 'left', convert-position('left', $numbering-position), convert-position('left', $running-content-position));
 @include page-structure('chapter', 'right', convert-position('right', $numbering-position), convert-position('right', $running-content-position));
 
 // Back Matter
-@page back-matter:first-of-group {
+@page back-matter:#{$first-page-pseudo} {
   @include blank-head-and-foot;
 }
 
-@include page-structure('back-matter', 'first-of-group', convert-position('first', $first-numbering-position), convert-position('first', $first-running-content-position));
+@include page-structure('back-matter', $first-page-pseudo, convert-position('first', $first-numbering-position), convert-position('first', $first-running-content-position));
 @include page-structure('back-matter', 'left', convert-position('left', $numbering-position), convert-position('left', $running-content-position));
 @include page-structure('back-matter', 'right', convert-position('right', $numbering-position), convert-position('right', $running-content-position));

--- a/assets/styles/variables/_elements.scss
+++ b/assets/styles/variables/_elements.scss
@@ -760,7 +760,7 @@ $blockquote-border-left-color: initial !default;
 /// are repeated on each page fragment. Prince 16+ defaults to `slice` per CSS spec.
 /// @type String
 /// @since 1.9.0
-$box-decoration-break: clone !default;
+$box-decoration-break: slice !default;
 
 /// Top margin for `<ol>` elements.
 /// @type String | Map

--- a/assets/styles/variables/_structure.scss
+++ b/assets/styles/variables/_structure.scss
@@ -58,6 +58,14 @@ $first-running-content-position: null !default;
 // $first-running-content-position: 'bottom-outside' !default;
 // TODO: Handle other positions based on recto-verso
 
+/// Page pseudo-class used for the first page of each section group.
+/// Prince 16+ uses 'first-of-group', Prince 15 and earlier use 'first'.
+/// Set to 'first' to restore Prince 15 behavior where the first page
+/// of each named page group was matched by :first.
+/// @type String
+/// @since 1.10.0
+$first-page-pseudo: 'first-of-group' !default;
+
 // Finally, for the running separator, it either exists or it doesn't,
 // so choose between two options (null, or defined content):
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14354,31 +14354,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/pressbooks-build-tools/node_modules/sugarss": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/sugarss/-/sugarss-5.0.1.tgz",
-      "integrity": "sha512-ctS5RYCBVvPoZAnzIaX5QSShK8ZiZxD5HUqSxlusvEMC+QZQIPCPOIJg6aceFX+K2rf4+SH89eu++h1Zmsr2nw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.3.3"
-      }
-    },
     "node_modules/pressbooks-build-tools/node_modules/vite": {
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
@@ -14489,24 +14464,6 @@
       },
       "peerDependencies": {
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/pressbooks-build-tools/node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/prettier": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buckram",
-  "version": "1.9.1",
+  "version": "1.10.0",
   "description": "Opinionated SCSS components for books (web, EPUB and PDF).",
   "scripts": {
     "build": "composer install && composer test",
@@ -45,7 +45,8 @@
         true,
         {
           "ignorePseudoClasses": [
-            "first-of-group"
+            "first-of-group",
+            "first"
           ]
         }
       ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buckram",
-  "version": "1.10.0",
+  "version": "1.9.1",
   "description": "Opinionated SCSS components for books (web, EPUB and PDF).",
   "scripts": {
     "build": "composer install && composer test",


### PR DESCRIPTION
This pull request updates how the codebase handles the CSS pseudo-class for the first page of each section group, making it configurable via a new `$first-page-pseudo` variable. This improves compatibility with different versions of Prince (a PDF rendering engine) and centralizes the pseudo-class logic. Additionally, a default value for `$box-decoration-break` is changed to match the CSS specification.

The most important changes are:

**Configurable first page pseudo-class:**
* Introduced the `$first-page-pseudo` variable in `_structure.scss` to allow easy switching between `'first-of-group'` (Prince 16+) and `'first'` (Prince 15 and earlier). This variable is now used throughout the codebase instead of hardcoding the pseudo-class.
* Updated all mixins and includes in `_mixins.scss` and `_running-content.scss` to use `#{$first-page-pseudo}` instead of `'first-of-group'`, ensuring consistent and configurable handling of first-page selectors. [[1]](diffhunk://#diff-75ba094f486efd0257613dd9bc81d7a4f0795ea13b8b4181ac625673b0c316bbL17-R17) [[2]](diffhunk://#diff-75ba094f486efd0257613dd9bc81d7a4f0795ea13b8b4181ac625673b0c316bbL29-R29) [[3]](diffhunk://#diff-75ba094f486efd0257613dd9bc81d7a4f0795ea13b8b4181ac625673b0c316bbL62-R62) [[4]](diffhunk://#diff-75ba094f486efd0257613dd9bc81d7a4f0795ea13b8b4181ac625673b0c316bbL74-R74) [[5]](diffhunk://#diff-75ba094f486efd0257613dd9bc81d7a4f0795ea13b8b4181ac625673b0c316bbL220-R220) [[6]](diffhunk://#diff-75ba094f486efd0257613dd9bc81d7a4f0795ea13b8b4181ac625673b0c316bbL235-R235) [[7]](diffhunk://#diff-75ba094f486efd0257613dd9bc81d7a4f0795ea13b8b4181ac625673b0c316bbL293-R293) [[8]](diffhunk://#diff-75ba094f486efd0257613dd9bc81d7a4f0795ea13b8b4181ac625673b0c316bbL308-R308) [[9]](diffhunk://#diff-75ba094f486efd0257613dd9bc81d7a4f0795ea13b8b4181ac625673b0c316bbL362-R362) [[10]](diffhunk://#diff-75ba094f486efd0257613dd9bc81d7a4f0795ea13b8b4181ac625673b0c316bbL387-R387) [[11]](diffhunk://#diff-75ba094f486efd0257613dd9bc81d7a4f0795ea13b8b4181ac625673b0c316bbL399-R399) [[12]](diffhunk://#diff-75ba094f486efd0257613dd9bc81d7a4f0795ea13b8b4181ac625673b0c316bbL412-R412) [[13]](diffhunk://#diff-75ba094f486efd0257613dd9bc81d7a4f0795ea13b8b4181ac625673b0c316bbL432-R432) [[14]](diffhunk://#diff-75ba094f486efd0257613dd9bc81d7a4f0795ea13b8b4181ac625673b0c316bbL441-R441) [[15]](diffhunk://#diff-75ba094f486efd0257613dd9bc81d7a4f0795ea13b8b4181ac625673b0c316bbL453-R453) [[16]](diffhunk://#diff-75ba094f486efd0257613dd9bc81d7a4f0795ea13b8b4181ac625673b0c316bbL464-R470) [[17]](diffhunk://#diff-75ba094f486efd0257613dd9bc81d7a4f0795ea13b8b4181ac625673b0c316bbL479-R479) [[18]](diffhunk://#diff-75ba094f486efd0257613dd9bc81d7a4f0795ea13b8b4181ac625673b0c316bbL490-R496) [[19]](diffhunk://#diff-18a08da01360d97b3534db67d9015dcf5c85774bc39c792ea2b9896f3ea4a98bL54-R55) [[20]](diffhunk://#diff-18a08da01360d97b3534db67d9015dcf5c85774bc39c792ea2b9896f3ea4a98bL65-R71) [[21]](diffhunk://#diff-18a08da01360d97b3534db67d9015dcf5c85774bc39c792ea2b9896f3ea4a98bL83-R133)

**CSS variable update:**
* Changed the default value of `$box-decoration-break` in `_elements.scss` from `clone` to `slice` to match the CSS specification and Prince 16+ defaults.

**Linting and development tooling:**
* Updated the `ignorePseudoClasses` list in `package.json` to include both `'first-of-group'` and `'first'`, preventing stylelint errors when using the new variable.