### PR TITLE
fix: keep wrapped links clickable and single-tagged in PDF export

### DIFF
--- a/assets/styles/components/elements/_links.scss
+++ b/assets/styles/components/elements/_links.scss
@@ -16,6 +16,18 @@
 }
 
 @if $type == 'prince' {
+  // Render each anchor as a single atomic box so PrinceXML emits one PDF link
+  // rectangle (and one OBJR tag) for the whole anchor, even when a long URL
+  // wraps across lines. This keeps the entire URL clickable
+  // (pressbooks/pressbooks#2512) and stops screen readers repeating the link
+  // from duplicate OBJR tags (pressbooks/private#2394). max-width and
+  // overflow-wrap let the URL wrap inside the box instead of overflowing.
+  a {
+    display: inline-block;
+    max-width: 100%;
+    overflow-wrap: break-word;
+  }
+
   .print a {
     text-decoration: $link-text-decoration-print;
   }


### PR DESCRIPTION
## Problem

When a long URL inside an `<a href>` anchor wraps across lines in the PrinceXML PDF (digital) export, two related defects appear:

- **[pressbooks/pressbooks#2512](https://github.com/pressbooks/pressbooks/issues/2512)** — only the fragment on the first line stays clickable, and its target is truncated to the text before the first `/`; the second line isn't clickable at all.
- **pressbooks/private#2394** — PrinceXML emits a separate PDF link rectangle (and `OBJR` tag) for *each* line-box fragment of the wrapped anchor, so screen readers announce the same link multiple times.

Per the [PrinceXML maintainer](https://www.princexml.com/forum/topic/4147/when-a-link-wraps-across-pages-it-breaks), a properly-formed anchor should wrap and link fine — the lever is in the CSS we feed Prince.

## Fix

Render anchors as a single atomic `inline-block` box in the **prince** build:

```scss
@if $type == 'prince' {
  a {
    display: inline-block;     // one box → one link rectangle → one OBJR
    max-width: 100%;           // keep the box inside the column
    overflow-wrap: break-word; // wrap long URLs inside the box, not overflow
  }
}
```

- One box ⇒ one link rectangle ⇒ the entire wrapped URL is clickable (#2512) and only one `OBJR` is produced (#2394).
- `hyphens: none` for non-web already landed in #422, which removes the spurious `press-books` hyphenation that also fragmented the annotation.

## Scope

Prince-only. EPUB is reflowable and has no `OBJR`/pagination link-fragmentation problem; `inline-block` on links there would risk anchors overflowing narrow viewports, so it is intentionally excluded.

## Testing

Verified in a digital PDF export (Prince 16 via DocRaptor) with a long wrapping URL:
- entire wrapped URL is clickable and resolves to the full href;
- a single `OBJR` tag per link;
- no URL hyphenation;
- short inline links in justified paragraphs render normally.

`npm run lint` passes.

Fixes pressbooks/pressbooks#2512